### PR TITLE
chore: bumps the MSRV to 1.82.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,9 +23,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - name: Install clippy
+      - name: Install `cargo-hack`
+        run: cargo install cargo-hack --locked
+      - name: Install `cargo clippy`
         run: rustup component add clippy
-      - run: cargo clippy --all-features -- --deny warnings
+      - run: cargo hack --each-feature clippy -- --deny warnings
 
   test:
     runs-on: ubuntu-latest
@@ -33,7 +35,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo test --all-features
+      - name: Install `cargo-hack`
+        run: cargo install cargo-hack --locked
+      - run: cargo hack test --each-feature
 
   test-examples:
     runs-on: ubuntu-latest
@@ -41,7 +45,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo test --all-features --examples
+      - name: Install `cargo-hack`
+        run: cargo install cargo-hack --locked
+      - run: cargo hack test --each-feature --examples
 
   test-compare-crossmap:
     runs-on: ubuntu-latest
@@ -65,9 +71,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-      - name: Install cargo-msrv
-        run: cargo binstall -y --version 0.16.0-beta.23 cargo-msrv
+      - name: Install `cargo-msrv`
+        run: cargo install cargo-msrv --locked
+      - name: Install `cargo-hack`
+        run: cargo install cargo-hack --locked
       - name: Verify the MSRV
-        run: cargo msrv verify --output-format minimal --all-features
+        run: cargo msrv verify -- cargo hack --each-feature check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/stjude-rust-labs/chainfile"
 repository = "https://github.com/stjude-rust-labs/chainfile"
 documentation = "https://docs.rs/chainfile"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.82.0"
 
 [dependencies]
 omics = { version = "0.2.0", features = ["coordinate", "position-u64"] }

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ cargo clippy --all-features
 cargo fmt --check
 ```
 
-## Minumum Supported Rust Version (MSRV)
+## Minimum Supported Rust Version (MSRV)
 
-This crate is designed to work with Rust version 1.72.0 or later. It may, by
+This crate is designed to work with Rust version 1.82.0 or later. It may, by
 happenstance, work with earlier versions of Rust.
 
 ## 🤝 Contributing

--- a/examples/chain_check.rs
+++ b/examples/chain_check.rs
@@ -120,9 +120,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let results = match machine.liftover(interval.clone()) {
             Some(results) => results,
             None => {
-                println!(
-                    "INFO: region {interval} is not included in the query genome."
-                );
+                println!("INFO: region {interval} is not included in the query genome.");
                 continue;
             }
         };
@@ -172,28 +170,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let positive_matched = (1.0 - (positive_mismatches as f64 / positive_positions as f64)) * 100.0;
-    println!(
-        "> Positive strand mismatches found: {positive_mismatches}"
-    );
-    println!(
-        "> Positive strand positions checked: {positive_positions}"
-    );
-    println!(
-        "> Percentage match for positive stranded query regions: {positive_matched:.1}%"
-    );
+    println!("> Positive strand mismatches found: {positive_mismatches}");
+    println!("> Positive strand positions checked: {positive_positions}");
+    println!("> Percentage match for positive stranded query regions: {positive_matched:.1}%");
 
     println!();
 
     let negative_matched = (1.0 - (negative_mismatches as f64 / negative_positions as f64)) * 100.0;
-    println!(
-        "> Negative strand mismatches found: {negative_mismatches}"
-    );
-    println!(
-        "> Negative strand positions checked: {negative_positions}"
-    );
-    println!(
-        "> Percentage match for negative stranded regions: {negative_matched:.1}%"
-    );
+    println!("> Negative strand mismatches found: {negative_mismatches}");
+    println!("> Negative strand positions checked: {negative_positions}");
+    println!("> Percentage match for negative stranded regions: {negative_matched:.1}%");
 
     Ok(())
 }

--- a/examples/chain_check.rs
+++ b/examples/chain_check.rs
@@ -121,8 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(results) => results,
             None => {
                 println!(
-                    "INFO: region {} is not included in the query genome.",
-                    interval
+                    "INFO: region {interval} is not included in the query genome."
                 );
                 continue;
             }
@@ -166,40 +165,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let total_matched = (1.0 - (total_mismatches as f64 / total_positions as f64)) * 100.0;
-    println!("Total mismatches found: {}", total_mismatches);
-    println!("Total positions checked: {}", total_positions);
-    println!("Percentage match for all regions: {:.1}%", total_matched);
+    println!("Total mismatches found: {total_mismatches}");
+    println!("Total positions checked: {total_positions}");
+    println!("Percentage match for all regions: {total_matched:.1}%");
 
     println!();
 
     let positive_matched = (1.0 - (positive_mismatches as f64 / positive_positions as f64)) * 100.0;
     println!(
-        "> Positive strand mismatches found: {}",
-        positive_mismatches
+        "> Positive strand mismatches found: {positive_mismatches}"
     );
     println!(
-        "> Positive strand positions checked: {}",
-        positive_positions
+        "> Positive strand positions checked: {positive_positions}"
     );
     println!(
-        "> Percentage match for positive stranded query regions: {:.1}%",
-        positive_matched
+        "> Percentage match for positive stranded query regions: {positive_matched:.1}%"
     );
 
     println!();
 
     let negative_matched = (1.0 - (negative_mismatches as f64 / negative_positions as f64)) * 100.0;
     println!(
-        "> Negative strand mismatches found: {}",
-        negative_mismatches
+        "> Negative strand mismatches found: {negative_mismatches}"
     );
     println!(
-        "> Negative strand positions checked: {}",
-        negative_positions
+        "> Negative strand positions checked: {negative_positions}"
     );
     println!(
-        "> Percentage match for negative stranded regions: {:.1}%",
-        negative_matched
+        "> Percentage match for negative stranded regions: {negative_matched:.1}%"
     );
 
     Ok(())

--- a/examples/chain_count.rs
+++ b/examples/chain_count.rs
@@ -28,8 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!(
-        "Counted {} alignment sections and {} alignment data entries.",
-        sections, alignment_data_entries
+        "Counted {sections} alignment sections and {alignment_data_entries} alignment data entries."
     );
 
     Ok(())

--- a/examples/chain_count.rs
+++ b/examples/chain_count.rs
@@ -28,7 +28,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!(
-        "Counted {sections} alignment sections and {alignment_data_entries} alignment data entries."
+        "Counted {sections} alignment sections and {alignment_data_entries} alignment data \
+         entries."
     );
 
     Ok(())

--- a/examples/chain_view.rs
+++ b/examples/chain_view.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .modify(Rows::new(1..), Alignment::left())
         .to_string();
 
-    println!("{}", table);
+    println!("{table}");
 
     Ok(())
 }

--- a/examples/liftover.rs
+++ b/examples/liftover.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match results {
         Some(results) => {
             for result in results {
-                println!("{}", result);
+                println!("{result}");
             }
         }
         None => println!("Does not exist in new genome"),

--- a/src/alignment/section/data.rs
+++ b/src/alignment/section/data.rs
@@ -43,13 +43,12 @@ impl std::fmt::Display for ParseError {
         match self {
             ParseError::IncorrectNumberOfFields(n) => write!(
                 f,
-                "invalid number of fields in alignment data: expected {} (non-terminating) or {} \
-                 (terminating) fields, found {} fields",
-                NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING, NUM_ALIGNMENT_DATA_FIELDS_TERMINATING, n
+                "invalid number of fields in alignment data: expected {NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING} (non-terminating) or {NUM_ALIGNMENT_DATA_FIELDS_TERMINATING} \
+                 (terminating) fields, found {n} fields"
             ),
-            ParseError::InvalidSize(err) => write!(f, "invalid size: {}", err),
-            ParseError::InvalidDt(err) => write!(f, "invalid dt: {}", err),
-            ParseError::InvalidDq(err) => write!(f, "invalid dq: {}", err),
+            ParseError::InvalidSize(err) => write!(f, "invalid size: {err}"),
+            ParseError::InvalidDt(err) => write!(f, "invalid dt: {err}"),
+            ParseError::InvalidDq(err) => write!(f, "invalid dq: {err}"),
         }
     }
 }

--- a/src/alignment/section/data.rs
+++ b/src/alignment/section/data.rs
@@ -43,8 +43,9 @@ impl std::fmt::Display for ParseError {
         match self {
             ParseError::IncorrectNumberOfFields(n) => write!(
                 f,
-                "invalid number of fields in alignment data: expected {NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING} (non-terminating) or {NUM_ALIGNMENT_DATA_FIELDS_TERMINATING} \
-                 (terminating) fields, found {n} fields"
+                "invalid number of fields in alignment data: expected \
+                 {NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING} (non-terminating) or \
+                 {NUM_ALIGNMENT_DATA_FIELDS_TERMINATING} (terminating) fields, found {n} fields"
             ),
             ParseError::InvalidSize(err) => write!(f, "invalid size: {err}"),
             ParseError::InvalidDt(err) => write!(f, "invalid dt: {err}"),

--- a/src/alignment/section/header.rs
+++ b/src/alignment/section/header.rs
@@ -51,7 +51,8 @@ impl std::fmt::Display for ParseError {
         match self {
             ParseError::IncorrectNumberOfFields(fields) => write!(
                 f,
-                "invalid number of fields in header: expected {NUM_HEADER_FIELDS} fields, found {fields} fields"
+                "invalid number of fields in header: expected {NUM_HEADER_FIELDS} fields, found \
+                 {fields} fields"
             ),
             ParseError::InvalidPrefix(prefix) => {
                 write!(

--- a/src/alignment/section/header.rs
+++ b/src/alignment/section/header.rs
@@ -51,26 +51,23 @@ impl std::fmt::Display for ParseError {
         match self {
             ParseError::IncorrectNumberOfFields(fields) => write!(
                 f,
-                "invalid number of fields in header: expected {} fields, found {} fields",
-                NUM_HEADER_FIELDS, fields
+                "invalid number of fields in header: expected {NUM_HEADER_FIELDS} fields, found {fields} fields"
             ),
             ParseError::InvalidPrefix(prefix) => {
                 write!(
                     f,
-                    "invalid prefix: expected \"{}\", found \"{}\"",
-                    HEADER_PREFIX, prefix
+                    "invalid prefix: expected \"{HEADER_PREFIX}\", found \"{prefix}\""
                 )
             }
-            ParseError::InvalidScore(err) => write!(f, "invalid score: {}", err),
+            ParseError::InvalidScore(err) => write!(f, "invalid score: {err}"),
             ParseError::InvalidReferenceSequence(err) => {
-                write!(f, "invalid reference sequence: {}", err)
+                write!(f, "invalid reference sequence: {err}")
             }
-            ParseError::InvalidQuerySequence(err) => write!(f, "invalid query sequence: {}", err),
-            ParseError::InvalidId(err) => write!(f, "invalid id: {}", err),
+            ParseError::InvalidQuerySequence(err) => write!(f, "invalid query sequence: {err}"),
+            ParseError::InvalidId(err) => write!(f, "invalid id: {err}"),
             ParseError::EndPositionExceedsSize(chrom, pos, size) => write!(
                 f,
-                "the end position ({}) exceeds the size of the chromosome `{}` ({})",
-                pos, chrom, size
+                "the end position ({pos}) exceeds the size of the chromosome `{chrom}` ({size})"
             ),
         }
     }

--- a/src/alignment/section/sections.rs
+++ b/src/alignment/section/sections.rs
@@ -45,17 +45,16 @@ impl std::fmt::Display for ParseError {
                 )
             }
             ParseError::BlankLineInSection(line_no) => {
-                write!(f, "found blank line in alignment section: line {}", line_no)
+                write!(f, "found blank line in alignment section: line {line_no}")
             }
             ParseError::DataBetweenSections(record) => write!(
                 f,
-                "found alignment data between sections: record: {}",
-                record
+                "found alignment data between sections: record: {record}"
             ),
             ParseError::HeaderInSection(record) => {
-                write!(f, "found header in alignment section: record: {}", record)
+                write!(f, "found header in alignment section: record: {record}")
             }
-            ParseError::Reader(err) => write!(f, "reader error: {}", err),
+            ParseError::Reader(err) => write!(f, "reader error: {err}"),
         }
     }
 }

--- a/src/alignment/section/sections.rs
+++ b/src/alignment/section/sections.rs
@@ -47,10 +47,9 @@ impl std::fmt::Display for ParseError {
             ParseError::BlankLineInSection(line_no) => {
                 write!(f, "found blank line in alignment section: line {line_no}")
             }
-            ParseError::DataBetweenSections(record) => write!(
-                f,
-                "found alignment data between sections: record: {record}"
-            ),
+            ParseError::DataBetweenSections(record) => {
+                write!(f, "found alignment data between sections: record: {record}")
+            }
             ParseError::HeaderInSection(record) => {
                 write!(f, "found header in alignment section: record: {record}")
             }

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -669,8 +669,7 @@ fn throw(args: &Args) -> Result<()> {
     let matched_percent = (n_matches as f64 * 100.0) / total_comparisons as f64;
 
     println!(
-        "`chainfile` and `CrossMap` matched in {matched_percent:.2}% of cases (n = {})",
-        total_comparisons
+        "`chainfile` and `CrossMap` matched in {matched_percent:.2}% of cases (n = {total_comparisons})"
     );
 
     if args.explore_mismatches.is_some() && !mismatches.is_empty() {

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -669,7 +669,8 @@ fn throw(args: &Args) -> Result<()> {
     let matched_percent = (n_matches as f64 * 100.0) / total_comparisons as f64;
 
     println!(
-        "`chainfile` and `CrossMap` matched in {matched_percent:.2}% of cases (n = {total_comparisons})"
+        "`chainfile` and `CrossMap` matched in {matched_percent:.2}% of cases (n = \
+         {total_comparisons})"
     );
 
     if args.explore_mismatches.is_some() && !mismatches.is_empty() {

--- a/src/liftover/machine/builder.rs
+++ b/src/liftover/machine/builder.rs
@@ -31,8 +31,8 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::InvalidSections(err) => write!(f, "invalid data section: {}", err),
-            Error::StepthroughError(err) => write!(f, "stepthrough error: {}", err),
+            Error::InvalidSections(err) => write!(f, "invalid data section: {err}"),
+            Error::StepthroughError(err) => write!(f, "stepthrough error: {err}"),
         }
     }
 }

--- a/src/liftover/stepthrough.rs
+++ b/src/liftover/stepthrough.rs
@@ -45,7 +45,8 @@ impl std::fmt::Display for Error {
             Error::IntervalStepthroughOutOfBounds(name, coordinate, magnitude) => {
                 write!(
                     f,
-                    "interval stepthrough out of bounds: moving {name} from {coordinate} by {magnitude}"
+                    "interval stepthrough out of bounds: moving {name} from {coordinate} by \
+                     {magnitude}"
                 )
             }
             Error::Interval(err) => write!(f, "interval error: {err}"),

--- a/src/liftover/stepthrough.rs
+++ b/src/liftover/stepthrough.rs
@@ -45,13 +45,12 @@ impl std::fmt::Display for Error {
             Error::IntervalStepthroughOutOfBounds(name, coordinate, magnitude) => {
                 write!(
                     f,
-                    "interval stepthrough out of bounds: moving {} from {} by {}",
-                    name, coordinate, magnitude
+                    "interval stepthrough out of bounds: moving {name} from {coordinate} by {magnitude}"
                 )
             }
-            Error::Interval(err) => write!(f, "interval error: {}", err),
+            Error::Interval(err) => write!(f, "interval error: {err}"),
             Error::InvalidIntervalPair(err) => {
-                write!(f, "invalid interval pair: {}", err)
+                write!(f, "invalid interval pair: {err}")
             }
             Error::MisalignedDataSection => write!(
                 f,

--- a/src/liftover/stepthrough/interval_pair.rs
+++ b/src/liftover/stepthrough/interval_pair.rs
@@ -20,9 +20,8 @@ impl std::fmt::Display for Error {
         match self {
             Error::EntityCountsDontMatch(reference, query) => write!(
                 f,
-                "reference interval entity count ({}) doesn't match query interval entity count \
-                 ({})",
-                reference, query
+                "reference interval entity count ({reference}) doesn't match query interval entity count \
+                 ({query})"
             ),
             Error::Interval(err) => write!(f, "interval error: {err}"),
         }

--- a/src/liftover/stepthrough/interval_pair.rs
+++ b/src/liftover/stepthrough/interval_pair.rs
@@ -20,8 +20,8 @@ impl std::fmt::Display for Error {
         match self {
             Error::EntityCountsDontMatch(reference, query) => write!(
                 f,
-                "reference interval entity count ({reference}) doesn't match query interval entity count \
-                 ({query})"
+                "reference interval entity count ({reference}) doesn't match query interval \
+                 entity count ({query})"
             ),
             Error::Interval(err) => write!(f, "interval error: {err}"),
         }

--- a/src/line.rs
+++ b/src/line.rs
@@ -32,13 +32,12 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::InvalidHeaderRecord { inner, line } => {
-                write!(f, "invalid header record: {}\n\nline: `{}`", inner, line)
+                write!(f, "invalid header record: {inner}\n\nline: `{line}`")
             }
             Error::InvalidAlignmentDataRecord { inner, line } => {
                 write!(
                     f,
-                    "invalid alignment data record: {}\n\nline: `{}`",
-                    inner, line
+                    "invalid alignment data record: {inner}\n\nline: `{line}`"
                 )
             }
         }
@@ -100,8 +99,8 @@ impl std::fmt::Display for Line {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Line::Empty => write!(f, ""),
-            Line::Header(record) => write!(f, "{}", record),
-            Line::AlignmentData(record) => write!(f, "{}", record),
+            Line::Header(record) => write!(f, "{record}"),
+            Line::AlignmentData(record) => write!(f, "{record}"),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -27,8 +27,8 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Io(err) => write!(f, "i/o error: {}", err),
-            Error::Line(err) => write!(f, "line error: {}", err),
+            Error::Io(err) => write!(f, "i/o error: {err}"),
+            Error::Line(err) => write!(f, "line error: {err}"),
         }
     }
 }


### PR DESCRIPTION
Hi Clyde or other St Jude contributor,

`chainfile` requires Rust 1.82+. Otherwise dependency `icu_properties` fails:
```
error: package `icu_properties v2.0.1` cannot be built because it requires rustc 1.82 or newer, while the currently active rustc version is 1.72.0
Either upgrade to rustc 1.82 or newer
```

This doesn't need a version bump or an entry in CHANGELOG.md, because the crate's API didn't change. That is, unless you want to publish to crates.io, but since nobody was asking for it... If you do want to publish to crates.io, I'll update the minor version and CHANGELOG.md, I'll rebase/squash and force push.

If you require/want me to create a tracking issue, I will do so, and I'll refer to it from the commit.

Low burner side note about the GitHub issue template:
GitHub doesn't seem to allow me to choose a reviewer or an assignee. You may want to test whether that ability differs between stjude-rust-labs GitHub organization members and the rest of the contributors.

Looking forward to contributing more.