### PR TITLE
chore: Readme about cargo fmt warnings on stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,11 @@ following checks.
 ```bash
 # Run the project's tests.
 cargo test --all-features
-```
 
 # Ensure the project doesn't have any linting warnings.
-`cargo clippy --all-features`
+cargo clippy --all-features
 
 # Ensure the project passes `cargo fmt`.
-Suggest using `nightly` toolchain. If you use `stable`, then ignore any
-warnings mentioning "unstable features".
-```bash
 cargo +nightly fmt --check
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,16 @@ following checks.
 ```bash
 # Run the project's tests.
 cargo test --all-features
+```
 
 # Ensure the project doesn't have any linting warnings.
-cargo clippy --all-features
+`cargo clippy --all-features`
 
 # Ensure the project passes `cargo fmt`.
-cargo fmt --check
+Suggest using `nightly` toolchain. If you use `stable`, then ignore any
+warnings mentioning "unstable features".
+```bash
+cargo +nightly fmt --check
 ```
 
 ## Minimum Supported Rust Version (MSRV)


### PR DESCRIPTION
If you think it's necessary to update CHANGELOG for this, I'll do so.