### PR TITLE
feat: groups liftover results by chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- `Machine::liftover()` now returns results grouped by chain via `LiftoverResult`,
+  making it possible to distinguish ambiguous mappings (multiple chains) from
+  straddle splits (multiple segments within one chain)
+  ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
+- `LiftoverResult` exposes the full chain header via `chain()` and the mapping
+  segments via `segments()` and `into_segments()`
+  ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
+- Duplicate chain IDs with inconsistent headers are now detected at build time
+  in `liftover::machine::Builder`
+  ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
+
+### Changed
+
+- All error types across the crate now use `thiserror`
+  ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
+- MSRV bumped to 1.85.0
+  ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
+
 ## 0.3.0 - 01-03-2025
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = { version = "0.8.5", optional = true }
 regex = "1.11.1"
 reqwest = { version = "0.12.12", features = ["blocking"], optional = true }
 rust-lapper = "1.1.0"
+thiserror = "2.0.18"
 tempdir = { version = "0.3.7", optional = true }
 tracing = { version = "0.1.40", optional = true }
 tracing-log = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/stjude-rust-labs/chainfile"
 repository = "https://github.com/stjude-rust-labs/chainfile"
 documentation = "https://docs.rs/chainfile"
 edition = "2021"
-rust-version = "1.83.0"
+rust-version = "1.85.0"
 
 [dependencies]
 omics = { version = "0.2.0", features = ["coordinate", "position-u64"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/stjude-rust-labs/chainfile"
 repository = "https://github.com/stjude-rust-labs/chainfile"
 documentation = "https://docs.rs/chainfile"
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.83.0"
 
 [dependencies]
 omics = { version = "0.2.0", features = ["coordinate", "position-u64"] }

--- a/examples/chain_check.rs
+++ b/examples/chain_check.rs
@@ -129,19 +129,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             for segment in chain_result.into_segments() {
                 let query_strand = segment.query().strand();
 
-                let query_sequence = query
-                    .get(segment.query().contig().as_str())
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "query FASTA did not contain necessary contig \"{}\": are the FASTA \
-                             files and chain file correct?",
-                            segment.query().contig()
-                        )
-                    });
+                let query_sequence =
+                    query
+                        .get(segment.query().contig().as_str())
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "query FASTA did not contain necessary contig \"{}\": are the \
+                                 FASTA files and chain file correct?",
+                                segment.query().contig()
+                            )
+                        });
 
                 let (reference_interval, query_interval) = segment.into_parts();
-                let reference =
-                    get_sequence_for_interval(reference_sequence, reference_interval);
+                let reference = get_sequence_for_interval(reference_sequence, reference_interval);
                 let query = get_sequence_for_interval(query_sequence, query_interval);
 
                 assert_eq!(reference.len(), query.len());

--- a/examples/chain_check.rs
+++ b/examples/chain_check.rs
@@ -125,37 +125,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        for region in results {
-            let query_strand = region.query().strand();
+        for chain_result in results {
+            for segment in chain_result.into_segments() {
+                let query_strand = segment.query().strand();
 
-            let query_sequence = query
-                .get(region.query().contig().as_str())
-                .unwrap_or_else(|| {
-                    panic!(
-                        "query FASTA did not contain necessary contig \"{}\": are the FASTA files \
-                         and chain file correct?",
-                        region.query().contig()
-                    )
-                });
+                let query_sequence = query
+                    .get(segment.query().contig().as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "query FASTA did not contain necessary contig \"{}\": are the FASTA \
+                             files and chain file correct?",
+                            segment.query().contig()
+                        )
+                    });
 
-            let (reference_interval, query_interval) = region.into_parts();
-            let reference = get_sequence_for_interval(reference_sequence, reference_interval);
-            let query = get_sequence_for_interval(query_sequence, query_interval);
+                let (reference_interval, query_interval) = segment.into_parts();
+                let reference =
+                    get_sequence_for_interval(reference_sequence, reference_interval);
+                let query = get_sequence_for_interval(query_sequence, query_interval);
 
-            assert_eq!(reference.len(), query.len());
+                assert_eq!(reference.len(), query.len());
 
-            let positions = query.len();
-            let mismatches = count_mismatches(&reference, &query);
+                let positions = query.len();
+                let mismatches = count_mismatches(&reference, &query);
 
-            total_positions += positions;
-            total_mismatches += mismatches;
+                total_positions += positions;
+                total_mismatches += mismatches;
 
-            if query_strand == Strand::Positive {
-                positive_positions += positions;
-                positive_mismatches += mismatches;
-            } else {
-                negative_positions += positions;
-                negative_mismatches += mismatches;
+                if query_strand == Strand::Positive {
+                    positive_positions += positions;
+                    positive_mismatches += mismatches;
+                } else {
+                    negative_positions += positions;
+                    negative_mismatches += mismatches;
+                }
             }
         }
     }

--- a/examples/liftover.rs
+++ b/examples/liftover.rs
@@ -22,9 +22,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let results = machine.liftover(interval);
 
     match results {
-        Some(results) => {
-            for result in results {
-                println!("{result}");
+        Some(chains) => {
+            for chain_liftover in chains {
+                println!("chain {} (score {})", chain_liftover.chain().id(), chain_liftover.chain().score());
+                for segment in chain_liftover.segments() {
+                    println!("  {segment}");
+                }
             }
         }
         None => println!("Does not exist in new genome"),

--- a/examples/liftover.rs
+++ b/examples/liftover.rs
@@ -24,7 +24,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match results {
         Some(chains) => {
             for chain_liftover in chains {
-                println!("chain {} (score {})", chain_liftover.chain().id(), chain_liftover.chain().score());
+                println!(
+                    "chain {} (score {})",
+                    chain_liftover.chain().id(),
+                    chain_liftover.chain().score()
+                );
                 for segment in chain_liftover.segments() {
                     println!("  {segment}");
                 }

--- a/src/alignment/section/builder.rs
+++ b/src/alignment/section/builder.rs
@@ -1,6 +1,7 @@
 //! Builders for an alignment section.
 
 use nonempty::NonEmpty;
+use thiserror::Error;
 
 use crate::alignment::Section;
 use crate::alignment::section::data;
@@ -8,65 +9,38 @@ use crate::alignment::section::header;
 
 /// An error that occurs when a required field was never provided to the
 /// [`Builder`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum MissingError {
     /// No data was provided to the [`Builder`].
+    #[error("data")]
     Data,
 
     /// No header was provided to the [`Builder`].
+    #[error("header")]
     Header,
 }
-
-impl std::fmt::Display for MissingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MissingError::Data => write!(f, "data"),
-            MissingError::Header => write!(f, "header"),
-        }
-    }
-}
-
-impl std::error::Error for MissingError {}
 
 /// An error that occurs when a singular field was provided multiple times to
 /// the [`Builder`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum MultipleError {
     /// The header field was provided multiple times to the [`Builder`].
+    #[error("header")]
     Header,
 }
 
-impl std::fmt::Display for MultipleError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MultipleError::Header => write!(f, "header"),
-        }
-    }
-}
-
-impl std::error::Error for MultipleError {}
-
 /// An error related to a [`Builder`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// An error where a required field was never provided to the [`Builder`].
+    #[error("missing required field: {0}")]
     Missing(MissingError),
 
     /// An error where a singular field was provided to the [`Builder`] more
     /// than once.
+    #[error("singular field set multiple times: {0}")]
     Multiple(MultipleError),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Missing(err) => write!(f, "missing required field: {err}"),
-            Error::Multiple(err) => write!(f, "singular field set multiple times: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T> = std::result::Result<T, Error>;

--- a/src/alignment/section/data.rs
+++ b/src/alignment/section/data.rs
@@ -4,6 +4,7 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use omics::coordinate::position::Number;
+use thiserror::Error;
 
 use crate::alignment::section::data::record::Kind;
 
@@ -23,83 +24,52 @@ pub const NUM_ALIGNMENT_DATA_FIELDS_TERMINATING: usize = 1;
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /// An error related to the parsing of an alignment data record.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ParseError {
     /// An incorrect number of fields in the alignment data line.
+    #[error(
+        "invalid number of fields in alignment data: expected \
+         {NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING} (non-terminating) or \
+         {NUM_ALIGNMENT_DATA_FIELDS_TERMINATING} (terminating) fields, found {0} fields"
+    )]
     IncorrectNumberOfFields(usize),
 
     /// An invalid size.
+    #[error("invalid size: {0}")]
     InvalidSize(ParseIntError),
 
     /// An invalid dt.
+    #[error("invalid dt: {0}")]
     InvalidDt(ParseIntError),
 
     /// An invalid dq.
+    #[error("invalid dq: {0}")]
     InvalidDq(ParseIntError),
 }
 
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::IncorrectNumberOfFields(n) => write!(
-                f,
-                "invalid number of fields in alignment data: expected \
-                 {NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING} (non-terminating) or \
-                 {NUM_ALIGNMENT_DATA_FIELDS_TERMINATING} (terminating) fields, found {n} fields"
-            ),
-            ParseError::InvalidSize(err) => write!(f, "invalid size: {err}"),
-            ParseError::InvalidDt(err) => write!(f, "invalid dt: {err}"),
-            ParseError::InvalidDq(err) => write!(f, "invalid dq: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
-
 /// An error related to a [`Record`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// An invalid dt value for a non-terminating alignment data line.
+    #[error("expected value for dt in non-terminating alignment data line, found no value")]
     InvalidNonTerminatingDt,
 
     /// An invalid dq value for a non-terminating alignment data line.
+    #[error("expected value for dq in non-terminating alignment data line, found no value")]
     InvalidNonTerminatingDq,
 
     /// An invalid dt value for a terminating alignment data line.
+    #[error("expected no value for dt in terminating alignment data line, found value")]
     InvalidTerminatingDt,
 
     /// An invalid dq value for a terminating alignment data line.
+    #[error("expected no value for dq in terminating alignment data line, found value")]
     InvalidTerminatingDq,
 
     /// A parse error.
+    #[error("parse error: {0}")]
     Parse(ParseError),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::InvalidNonTerminatingDt => write!(
-                f,
-                "expected value for dt in non-terminating alignment data line, found no value"
-            ),
-            Error::InvalidNonTerminatingDq => write!(
-                f,
-                "expected value for dq in non-terminating alignment data line, found no value"
-            ),
-            Error::InvalidTerminatingDt => write!(
-                f,
-                "expected no value for dt in terminating alignment data line, found value"
-            ),
-            Error::InvalidTerminatingDq => write!(
-                f,
-                "expected no value for dq in terminating alignment data line, found value"
-            ),
-            Error::Parse(err) => write!(f, "parse error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T> = std::result::Result<T, Error>;

--- a/src/alignment/section/header.rs
+++ b/src/alignment/section/header.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use omics::coordinate::position::Number;
 pub use sequence::Sequence;
+use thiserror::Error;
 
 /// The prefix for a header record.
 pub const HEADER_PREFIX: &str = "chain";
@@ -22,76 +23,46 @@ pub const NUM_HEADER_FIELDS: usize = 13;
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /// An error associated with parsing a header record.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ParseError {
     /// An incorrect number of fields in the header line.
+    #[error(
+        "invalid number of fields in header: expected {NUM_HEADER_FIELDS} fields, found {0} fields"
+    )]
     IncorrectNumberOfFields(usize),
 
     /// An invalid prefix.
+    #[error("invalid prefix: expected \"{HEADER_PREFIX}\", found \"{0}\"")]
     InvalidPrefix(String),
 
     /// An invalid score.
+    #[error("invalid score: {0}")]
     InvalidScore(ParseIntError),
 
     /// An invalid reference sequence.
+    #[error("invalid reference sequence: {0}")]
     InvalidReferenceSequence(sequence::Error),
 
     /// An invalid query sequence.
+    #[error("invalid query sequence: {0}")]
     InvalidQuerySequence(sequence::Error),
 
     /// An invalid id.
+    #[error("invalid id: {0}")]
     InvalidId(ParseIntError),
 
     /// The end position exceeds the size of the chromosome.
+    #[error("the end position ({1}) exceeds the size of the chromosome `{0}` ({2})")]
     EndPositionExceedsSize(String, Number, Number),
 }
 
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::IncorrectNumberOfFields(fields) => write!(
-                f,
-                "invalid number of fields in header: expected {NUM_HEADER_FIELDS} fields, found \
-                 {fields} fields"
-            ),
-            ParseError::InvalidPrefix(prefix) => {
-                write!(
-                    f,
-                    "invalid prefix: expected \"{HEADER_PREFIX}\", found \"{prefix}\""
-                )
-            }
-            ParseError::InvalidScore(err) => write!(f, "invalid score: {err}"),
-            ParseError::InvalidReferenceSequence(err) => {
-                write!(f, "invalid reference sequence: {err}")
-            }
-            ParseError::InvalidQuerySequence(err) => write!(f, "invalid query sequence: {err}"),
-            ParseError::InvalidId(err) => write!(f, "invalid id: {err}"),
-            ParseError::EndPositionExceedsSize(chrom, pos, size) => write!(
-                f,
-                "the end position ({pos}) exceeds the size of the chromosome `{chrom}` ({size})"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
-
 /// An error related to a [`Record`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// A parse error.
+    #[error("parse error: {0}")]
     Parse(ParseError),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Parse(err) => write!(f, "parse error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T> = std::result::Result<T, Error>;

--- a/src/alignment/section/header/sequence.rs
+++ b/src/alignment/section/header/sequence.rs
@@ -9,6 +9,7 @@ use omics::coordinate::interval;
 use omics::coordinate::interval::interbase::Interval;
 use omics::coordinate::position::Number;
 use omics::coordinate::strand;
+use thiserror::Error;
 
 use crate::alignment::section::header::DELIMITER;
 
@@ -17,60 +18,40 @@ use crate::alignment::section::header::DELIMITER;
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /// Errors associated with parsing a sequence.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ParseError {
     /// An invalid chromosome size.
+    #[error("invalid chromosome size: {0}")]
     InvalidChromosomeSize(ParseIntError),
 
     /// An invalid strand.
+    #[error("invalid strand: {0}")]
     InvalidStrand(strand::Error),
 
     /// An invalid alignment start.
+    #[error("invalid alignment start: {0}")]
     InvalidAlignmentStart(ParseIntError),
 
     /// An invalid alignment end.
+    #[error("invalid alignment end: {0}")]
     InvalidAlignmentEnd(ParseIntError),
 }
 
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::InvalidChromosomeSize(err) => write!(f, "invalid chromosome size: {err}"),
-            ParseError::InvalidStrand(err) => write!(f, "invalid strand: {err}"),
-            ParseError::InvalidAlignmentStart(err) => write!(f, "invalid alignment start: {err}"),
-            ParseError::InvalidAlignmentEnd(err) => write!(f, "invalid alignment end: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
-
 /// An error related to a sequence.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// An interval error.
+    #[error("interval error: {0}")]
     Interval(interval::Error),
 
     /// A parse error.
+    #[error("parse error: {0}")]
     Parse(ParseError),
 
     /// The start position is greater than the end position.
+    #[error("start position greater than end position")]
     StartPositionGreaterThanEndPosition,
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Interval(err) => write!(f, "interval error: {err}"),
-            Error::Parse(err) => write!(f, "parse error: {err}"),
-            Error::StartPositionGreaterThanEndPosition => {
-                write!(f, "start position greater than end position")
-            }
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T> = std::result::Result<T, Error>;

--- a/src/alignment/section/sections.rs
+++ b/src/alignment/section/sections.rs
@@ -2,6 +2,8 @@
 
 use std::io::BufRead;
 
+use thiserror::Error;
+
 use crate::Line;
 use crate::Reader;
 use crate::alignment::Section;
@@ -17,69 +19,40 @@ use crate::reader;
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /// An error related to the parsing of an alignment section.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ParseError {
     /// The file abruptly ended before closing an alignment section.
+    #[error("the file abruptly ended in the middle of an alignment section")]
     AbruptEndInSection,
 
     /// There was a blank line within an alignment section.
+    #[error("found blank line in alignment section: line {0}")]
     BlankLineInSection(usize),
 
     /// Alignment data was found in between alignment sections.
+    #[error("found alignment data between sections: record: {0}")]
     DataBetweenSections(data::Record),
 
     /// There was a header record within an alignment section.
+    #[error("found header in alignment section: record: {0}")]
     HeaderInSection(header::Record),
 
     /// There was an issue reading from the underlying reader.
+    #[error("reader error: {0}")]
     Reader(reader::Error),
 }
 
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::AbruptEndInSection => {
-                write!(
-                    f,
-                    "the file abruptly ended in the middle of an alignment section"
-                )
-            }
-            ParseError::BlankLineInSection(line_no) => {
-                write!(f, "found blank line in alignment section: line {line_no}")
-            }
-            ParseError::DataBetweenSections(record) => {
-                write!(f, "found alignment data between sections: record: {record}")
-            }
-            ParseError::HeaderInSection(record) => {
-                write!(f, "found header in alignment section: record: {record}")
-            }
-            ParseError::Reader(err) => write!(f, "reader error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
-
 /// An error related to [`Sections`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// A builder error.
+    #[error("builder error: {0}")]
     Builder(builder::Error),
 
     /// A parse error.
+    #[error("parse error: {0}")]
     Parse(ParseError),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Builder(err) => write!(f, "builder error: {err}"),
-            Error::Parse(err) => write!(f, "parse error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T> = std::result::Result<T, Error>;

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -553,7 +553,7 @@ struct Args {
     explore_mismatches: Option<usize>,
 
     /// The number of positions to generate.
-    #[arg(short, default_value_t = 100_000_000)]
+    #[arg(short, default_value_t = 30_000_000)]
     n: usize,
 
     #[command(flatten)]
@@ -621,9 +621,7 @@ fn throw(args: &Args) -> Result<()> {
             .liftover(from_interval)
             .and_then(|results| {
                 // Select the result from the highest-scoring chain.
-                let result = results
-                    .into_iter()
-                    .max_by_key(|r| r.chain().score())?;
+                let result = results.into_iter().max_by_key(|r| r.chain().score())?;
 
                 let mut segments = result.into_segments();
                 assert!(

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -581,12 +581,17 @@ fn throw(args: &Args) -> Result<()> {
         .download_chain_file(&chain_name)
         .with_context(|| format!("chain file: downloading {}", &chain_name.name()))?;
 
+    let chainfile_load_start = std::time::Instant::now();
+
     let chain = File::open(&chain_file_path)
         .map(GzDecoder::new)
         .map(BufReader::new)
         .map(chainfile::Reader::new)?;
 
     let machine = liftover::machine::builder::Builder.try_build_from(chain)?;
+
+    let chainfile_load_elapsed = chainfile_load_start.elapsed();
+    info!("chainfile: chain file loaded in {chainfile_load_elapsed:.2?}");
     let query_contigs =
         Chromosomes::new(machine.query_chromosomes(), args.canonical_chromosomes_only);
     let mut reference_contigs = Chromosomes::new(
@@ -607,10 +612,18 @@ fn throw(args: &Args) -> Result<()> {
 
     let mut comparisons = Vec::new();
 
+    let crossmap_start = std::time::Instant::now();
+
     info!("crossmap: running liftover");
-    for (from, crossmap_result) in CrossMap::run_bed(&chain_file_path, &work_dir.input_bed_file())
-        .context("getting the `CrossMap` mappings")?
-    {
+    let crossmap_results = CrossMap::run_bed(&chain_file_path, &work_dir.input_bed_file())
+        .context("getting the `CrossMap` mappings")?;
+
+    let crossmap_elapsed = crossmap_start.elapsed();
+    info!("crossmap: liftover completed in {crossmap_elapsed:.2?}");
+
+    let chainfile_liftover_start = std::time::Instant::now();
+
+    for (from, crossmap_result) in crossmap_results {
         let start =
             Coordinate::<Interbase>::new(from.contig.as_str(), Strand::Positive, from.start);
         let end = Coordinate::<Interbase>::new(from.contig.as_str(), Strand::Positive, from.end);
@@ -659,6 +672,12 @@ fn throw(args: &Args) -> Result<()> {
 
         comparisons.push(Comparison::new(from, chainfile_result, crossmap_result));
     }
+
+    let chainfile_liftover_elapsed = chainfile_liftover_start.elapsed();
+    info!("chainfile: liftover completed in {chainfile_liftover_elapsed:.2?}");
+
+    let chainfile_total = chainfile_load_elapsed + chainfile_liftover_elapsed;
+    info!("chainfile: total (load + liftover) in {chainfile_total:.2?}");
 
     let total_comparisons = comparisons.len();
     let mismatches = comparisons

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -622,19 +622,27 @@ fn throw(args: &Args) -> Result<()> {
             .map(|mut results| {
                 assert!(
                     results.len() == 1,
-                    "single valued inputs should only ever produce one output contiguous interval \
-                     pair"
+                    "single valued inputs should only ever produce one liftover result"
                 );
 
                 // SAFETY: we just asserted that the length is one, so this will
                 // always unwrap.
                 let result = results.pop().unwrap();
+                let mut segments = result.into_segments();
                 assert!(
-                    result.reference().strand() == Strand::Positive,
+                    segments.len() == 1,
+                    "single valued inputs should only ever produce one segment"
+                );
+
+                // SAFETY: we just asserted that the length is one, so this will
+                // always unwrap.
+                let segment = segments.pop().unwrap();
+                assert!(
+                    segment.reference().strand() == Strand::Positive,
                     "strand should always be positive for reference"
                 );
 
-                let query = result.into_query();
+                let query = segment.into_query();
 
                 // NOTE: `CrossMap` always reports the results on the positive
                 // strand. This alters how the nucleotide is represented as a
@@ -673,109 +681,109 @@ fn throw(args: &Args) -> Result<()> {
          {total_comparisons})"
     );
 
-    if args.explore_mismatches.is_some() && !mismatches.is_empty() {
-        let sections = File::open(&chain_file_path)
-            .map(GzDecoder::new)
-            .map(BufReader::new)
-            .map(chainfile::Reader::new)?
-            .sections()
-            .collect::<Result<Vec<_>, _>>()
-            .context("rereading the chainfile sections")?
-            .into_iter()
-            .map(|section| {
-                section
-                    .reference_sequence()
-                    .interval()
-                    .map(|interval| (section, interval))
-            })
-            .collect::<Result<Vec<_>, sequence::Error>>()
-            .context("creating intervals from chainfile")?;
+    if let Some(take_n_mismatches) = args.explore_mismatches {
+        if !mismatches.is_empty() {
+            let sections = File::open(&chain_file_path)
+                .map(GzDecoder::new)
+                .map(BufReader::new)
+                .map(chainfile::Reader::new)?
+                .sections()
+                .collect::<Result<Vec<_>, _>>()
+                .context("rereading the chainfile sections")?
+                .into_iter()
+                .map(|section| {
+                    section
+                        .reference_sequence()
+                        .interval()
+                        .map(|interval| (section, interval))
+                })
+                .collect::<Result<Vec<_>, sequence::Error>>()
+                .context("creating intervals from chainfile")?;
 
-        // SAFETY: we just checked about that this is [`Some`] in the `if`
-        // statement, so this will always unwrap.
-        let take_n_mismatches = args.explore_mismatches.unwrap();
+            for (i, comparison) in mismatches.into_iter().enumerate().take(take_n_mismatches) {
+                warn!("== unmatched example #{} ==", i + 1);
+                warn!("reference: {}", comparison.from());
+                warn!("chainfile: {}", comparison.chainfile());
+                warn!("crossmap:  {}", comparison.crossmap());
+                warn!("  ↳ relevant alignment sections:");
 
-        for (i, comparison) in mismatches.into_iter().enumerate().take(take_n_mismatches) {
-            warn!("== unmatched example #{} ==", i + 1);
-            warn!("reference: {}", comparison.from());
-            warn!("chainfile: {}", comparison.chainfile());
-            warn!("crossmap:  {}", comparison.crossmap());
-            warn!("  ↳ relevant alignment sections:");
+                let coordinate = comparison
+                    .from()
+                    .clone()
+                    .into_coordinate(Strand::Positive)
+                    .nudge_forward()
+                    .unwrap();
 
-            let coordinate = comparison
-                .from()
-                .clone()
-                .into_coordinate(Strand::Positive)
-                .nudge_forward()
-                .unwrap();
+                for (section, interval) in &sections {
+                    if interval.contains_entity(&coordinate) {
+                        warn!("    ↳ {}", section.header());
 
-            for (section, interval) in &sections {
-                if interval.contains_entity(&coordinate) {
-                    warn!("    ↳ {}", section.header());
+                        for result in section.stepthrough().expect("step-through to be created") {
+                            let pairs = result?;
 
-                    for result in section.stepthrough().expect("step-through to be created") {
-                        let pairs = result?;
+                            if pairs.reference().contains_entity(&coordinate) {
+                                warn!("      ↳ {}", pairs);
 
-                        if pairs.reference().contains_entity(&coordinate) {
-                            warn!("      ↳ {}", pairs);
+                                let query = pairs.into_query();
+                                if query.strand() == Strand::Negative {
+                                    // (1) Find the size of the chromosome the query
+                                    // sits on.
+                                    let (_, size) = query_contigs
+                                        .chromosomes
+                                        .iter()
+                                        .find(|(chromosome, _)| {
+                                            chromosome == query.contig().as_str()
+                                        })
+                                        .expect("this should be found");
 
-                            let query = pairs.into_query();
-                            if query.strand() == Strand::Negative {
-                                // (1) Find the size of the chromosome the query
-                                // sits on.
-                                let (_, size) = query_contigs
-                                    .chromosomes
-                                    .iter()
-                                    .find(|(chromosome, _)| chromosome == query.contig().as_str())
-                                    .expect("this should be found");
+                                    // (2) Grab the existing coordinate parts.
+                                    let (old_start, old_end) = query.into_coordinates();
+                                    let (old_start_contig, old_start_strand, old_start_pos) =
+                                        old_start.into_parts();
+                                    let (old_end_contig, old_end_strand, old_end_pos) =
+                                        old_end.into_parts();
 
-                                // (2) Grab the existing coordinate parts.
-                                let (old_start, old_end) = query.into_coordinates();
-                                let (old_start_contig, old_start_strand, old_start_pos) =
-                                    old_start.into_parts();
-                                let (old_end_contig, old_end_strand, old_end_pos) =
-                                    old_end.into_parts();
+                                    // (3) Invert them using the current chromosome
+                                    // size.
 
-                                // (3) Invert them using the current chromosome
-                                // size.
+                                    // SAFETY: this should always unwrap, as we
+                                    // constructed this coordinate on the opposite
+                                    // strand successfully (and none of the
+                                    // operations here should cause it to not
+                                    // construct—unless, of course, there is a bug).
+                                    let new_start = Coordinate::<Interbase>::new(
+                                        old_start_contig,
+                                        old_start_strand.complement(),
+                                        *size as Number - old_start_pos.get(),
+                                    );
 
-                                // SAFETY: this should always unwrap, as we
-                                // constructed this coordinate on the opposite
-                                // strand successfully (and none of the
-                                // operations here should cause it to not
-                                // construct—unless, of course, there is a bug).
-                                let new_start = Coordinate::<Interbase>::new(
-                                    old_start_contig,
-                                    old_start_strand.complement(),
-                                    *size as Number - old_start_pos.get(),
-                                );
+                                    // SAFETY: this should always unwrap, as we
+                                    // constructed this coordinate on the opposite
+                                    // strand successfully (and none of the
+                                    // operations here should cause it to not
+                                    // construct—unless, of course, there is a bug).
+                                    let new_end = Coordinate::<Interbase>::new(
+                                        old_end_contig,
+                                        old_end_strand.complement(),
+                                        *size as Number - old_end_pos.get(),
+                                    );
 
-                                // SAFETY: this should always unwrap, as we
-                                // constructed this coordinate on the opposite
-                                // strand successfully (and none of the
-                                // operations here should cause it to not
-                                // construct—unless, of course, there is a bug).
-                                let new_end = Coordinate::<Interbase>::new(
-                                    old_end_contig,
-                                    old_end_strand.complement(),
-                                    *size as Number - old_end_pos.get(),
-                                );
-
-                                // SAFETY: this should always unwrap, as we
-                                // constructed this interval on the opposite
-                                // strand successfully (and none of the
-                                // operations here should cause it to not
-                                // construct—unless, of course, there is a bug).
-                                let interval = Interval::try_new(new_start, new_end).unwrap();
-                                warn!("        ↳ in other words, {}", interval);
-                            }
-                        };
+                                    // SAFETY: this should always unwrap, as we
+                                    // constructed this interval on the opposite
+                                    // strand successfully (and none of the
+                                    // operations here should cause it to not
+                                    // construct—unless, of course, there is a bug).
+                                    let interval = Interval::try_new(new_start, new_end).unwrap();
+                                    warn!("        ↳ in other words, {}", interval);
+                                }
+                            };
+                        }
                     }
                 }
-            }
 
-            if i < take_n_mismatches - 1 {
-                warn!("");
+                if i < take_n_mismatches - 1 {
+                    warn!("");
+                }
             }
         }
     }

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -619,23 +619,19 @@ fn throw(args: &Args) -> Result<()> {
 
         let chainfile_result = machine
             .liftover(from_interval)
-            .map(|mut results| {
-                assert!(
-                    results.len() == 1,
-                    "single valued inputs should only ever produce one liftover result"
-                );
+            .and_then(|results| {
+                // Select the result from the highest-scoring chain.
+                let result = results
+                    .into_iter()
+                    .max_by_key(|r| r.chain().score())?;
 
-                // SAFETY: we just asserted that the length is one, so this will
-                // always unwrap.
-                let result = results.pop().unwrap();
                 let mut segments = result.into_segments();
                 assert!(
                     segments.len() == 1,
-                    "single valued inputs should only ever produce one segment"
+                    "single-position queries should only ever produce one segment"
                 );
 
-                // SAFETY: we just asserted that the length is one, so this will
-                // always unwrap.
+                // SAFETY: we just asserted that the length is one.
                 let segment = segments.pop().unwrap();
                 assert!(
                     segment.reference().strand() == Strand::Positive,
@@ -656,12 +652,10 @@ fn throw(args: &Args) -> Result<()> {
 
                 let (contig, _, position) = query.into_start().into_parts();
 
-                LiftoverResult::Mapped(BedEntry::new_single_position(
+                Some(LiftoverResult::Mapped(BedEntry::new_single_position(
                     contig.into_inner(),
-                    // SAFETY: this should always unwrap, as the lower bound isn't
-                    // going to be used in this kind of thing.
                     position.get() as Number,
-                ))
+                )))
             })
             .unwrap_or(LiftoverResult::Unmapped);
 

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -553,7 +553,7 @@ struct Args {
     explore_mismatches: Option<usize>,
 
     /// The number of positions to generate.
-    #[arg(short, default_value_t = 1_000_000)]
+    #[arg(short, default_value_t = 100_000_000)]
     n: usize,
 
     #[command(flatten)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,11 @@
 //! let machine = chain::liftover::machine::Builder::default().try_build_from(reader)?;
 //!
 //! let interval = "seq0:+:3-4".parse::<Interval>()?;
-//! for result in machine.liftover(interval).unwrap() {
-//!     println!("{} -> {}", result.reference(), result.query());
+//! for chain_liftover in machine.liftover(interval).unwrap() {
+//!     println!("chain {} (score {})", chain_liftover.chain().id(), chain_liftover.chain().score());
+//!     for segment in chain_liftover.segments() {
+//!         println!("  {} -> {}", segment.reference(), segment.query());
+//!     }
 //! }
 //!
 //! # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,11 @@
 //!
 //! let interval = "seq0:+:3-4".parse::<Interval>()?;
 //! for chain_liftover in machine.liftover(interval).unwrap() {
-//!     println!("chain {} (score {})", chain_liftover.chain().id(), chain_liftover.chain().score());
+//!     println!(
+//!         "chain {} (score {})",
+//!         chain_liftover.chain().id(),
+//!         chain_liftover.chain().score()
+//!     );
 //!     for segment in chain_liftover.segments() {
 //!         println!("  {} -> {}", segment.reference(), segment.query());
 //!     }

--- a/src/liftover.rs
+++ b/src/liftover.rs
@@ -3,5 +3,6 @@
 pub mod machine;
 pub mod stepthrough;
 
+pub use machine::LiftoverResult;
 pub use machine::Machine;
 pub use stepthrough::StepThroughWithData;

--- a/src/liftover/machine.rs
+++ b/src/liftover/machine.rs
@@ -8,6 +8,7 @@ use omics::coordinate::interval::interbase::Interval;
 use omics::coordinate::position::Number;
 use rust_lapper as lapper;
 
+use crate::alignment::section::header::Record as Header;
 use crate::liftover::stepthrough::interval_pair::ContiguousIntervalPair;
 
 pub mod builder;
@@ -16,6 +17,47 @@ pub use builder::Builder;
 
 /// A dictionary of chromosome names and their size.
 pub type ChromosomeDictionary = HashMap<String, Number>;
+
+/// A mapping segment annotated with the chain from which it originated.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AnnotatedPair {
+    /// The chain from which this segment originated.
+    chain: Header,
+
+    /// The mapping segment.
+    pair: ContiguousIntervalPair,
+}
+
+/// The liftover results from a single chain.
+///
+/// Each chain produces one or more contiguous mapping segments. When a
+/// query interval spans a gap within a chain, the chain contributes
+/// multiple segments (one per aligned block that overlaps the query).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LiftoverResult {
+    /// The chain from which these liftover results originated.
+    chain: Header,
+
+    /// The mapping segments from this chain that overlap the query.
+    segments: Vec<ContiguousIntervalPair>,
+}
+
+impl LiftoverResult {
+    /// Gets the chain from which these liftover results originated.
+    pub fn chain(&self) -> &Header {
+        &self.chain
+    }
+
+    /// Gets the mapping segments.
+    pub fn segments(&self) -> &[ContiguousIntervalPair] {
+        &self.segments
+    }
+
+    /// Consumes `self` and returns the mapping segments.
+    pub fn into_segments(self) -> Vec<ContiguousIntervalPair> {
+        self.segments
+    }
+}
 
 /// A machine for lifting over coordinates from a reference genome to a query
 /// genome.
@@ -26,7 +68,7 @@ pub type ChromosomeDictionary = HashMap<String, Number>;
 pub struct Machine {
     /// The inner lookup table of positions in the reference genome to positions
     /// in the query genome for each contig in the reference genome.
-    inner: HashMap<Contig, lapper::Lapper<Number, ContiguousIntervalPair>>,
+    inner: HashMap<Contig, lapper::Lapper<Number, AnnotatedPair>>,
 
     /// The reference chromosome corpus.
     reference_chromosomes: ChromosomeDictionary,
@@ -48,13 +90,12 @@ impl Machine {
         &self.query_chromosomes
     }
 
-    /// Gets a reference to the inner hashmap.
-    pub fn inner(&self) -> &HashMap<Contig, lapper::Lapper<Number, ContiguousIntervalPair>> {
-        &self.inner
-    }
-
     /// Performs a liftover from the specified `interval` to the query genome.
-    pub fn liftover(&self, interval: Interval) -> Option<Vec<ContiguousIntervalPair>> {
+    ///
+    /// Results are grouped by the chain from which each mapping segment
+    /// originated. Each [`LiftoverResult`] contains one or more contiguous
+    /// segments from a single chain, along with the chain's header.
+    pub fn liftover(&self, interval: Interval) -> Option<Vec<LiftoverResult>> {
         let entry = self.inner.get(interval.contig())?;
 
         let (start, stop) = match interval.strand() {
@@ -74,17 +115,38 @@ impl Machine {
 
         let strand = interval.strand();
 
-        let results = entry
+        let clamped = entry
             .find(start, stop)
             .map(|e| e.val.clone())
-            .filter(|i| i.reference().strand() == strand)
-            .map(move |pair| pair.clamp(interval.clone()).unwrap())
+            .filter(|ap| ap.pair.reference().strand() == strand)
+            .map(|ap| {
+                // SAFETY: the lapper guarantees that `ap.pair` overlaps
+                // `interval`, so `clamp()` will always succeed.
+                let pair = ap.pair.clamp(interval.clone()).unwrap();
+                (pair, ap.chain)
+            })
             .collect::<Vec<_>>();
 
-        match results.is_empty() {
-            true => None,
-            false => Some(results),
+        if clamped.is_empty() {
+            return None;
         }
+
+        let mut groups = HashMap::<usize, (Header, Vec<ContiguousIntervalPair>)>::new();
+
+        for (pair, chain) in clamped {
+            groups
+                .entry(chain.id())
+                .or_insert_with(|| (chain, Vec::new()))
+                .1
+                .push(pair);
+        }
+
+        let results = groups
+            .into_values()
+            .map(|(chain, segments)| LiftoverResult { chain, segments })
+            .collect::<Vec<_>>();
+
+        Some(results)
     }
 }
 
@@ -107,11 +169,12 @@ mod tests {
         let to = Coordinate::new("seq0", Strand::Positive, 7u64);
 
         let interval = Interval::try_new(from, to)?;
-        let mut results = machine.liftover(interval).unwrap();
+        let results = machine.liftover(interval).unwrap();
 
         assert_eq!(results.len(), 1);
+        assert_eq!(results[0].segments().len(), 1);
 
-        let result = results.pop().unwrap();
+        let result = &results[0].segments()[0];
 
         assert_eq!(result.reference().contig().as_str(), "seq0");
         assert_eq!(result.reference().start().strand(), Strand::Positive);
@@ -138,11 +201,12 @@ mod tests {
         let to = Coordinate::new("seq0", Strand::Negative, 1u64);
 
         let interval = Interval::try_new(from, to)?;
-        let mut results = machine.liftover(interval).unwrap();
+        let results = machine.liftover(interval).unwrap();
 
         assert_eq!(results.len(), 1);
+        assert_eq!(results[0].segments().len(), 1);
 
-        let result = results.pop().unwrap();
+        let result = &results[0].segments()[0];
 
         assert_eq!(result.reference().contig().as_str(), "seq0");
         assert_eq!(result.reference().start().strand(), Strand::Negative);
@@ -170,11 +234,12 @@ mod tests {
         let to = Coordinate::new("seq0", Strand::Positive, 7u64);
 
         let interval = Interval::try_new(from, to)?;
-        let mut results = machine.liftover(interval).unwrap();
+        let results = machine.liftover(interval).unwrap();
 
         assert_eq!(results.len(), 1);
+        assert_eq!(results[0].segments().len(), 1);
 
-        let result = results.pop().unwrap();
+        let result = &results[0].segments()[0];
 
         assert_eq!(result.reference().contig().as_str(), "seq0");
         assert_eq!(result.reference().start().strand(), Strand::Positive);
@@ -202,11 +267,12 @@ mod tests {
         let to = Coordinate::new("seq0", Strand::Negative, 1u64);
 
         let interval = Interval::try_new(from, to)?;
-        let mut results = machine.liftover(interval).unwrap();
+        let results = machine.liftover(interval).unwrap();
 
         assert_eq!(results.len(), 1);
+        assert_eq!(results[0].segments().len(), 1);
 
-        let result = results.pop().unwrap();
+        let result = &results[0].segments()[0];
 
         assert_eq!(result.reference().contig().as_str(), "seq0");
         assert_eq!(result.reference().start().strand(), Strand::Negative);
@@ -255,6 +321,59 @@ mod tests {
         let results = machine.liftover(interval);
 
         assert_eq!(results, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouped_by_chain() -> Result<(), Box<dyn std::error::Error>> {
+        // Two chains covering the same region on `seq0`, mapping to
+        // `seq1` and `seq2` respectively.
+        let data =
+            b"chain 100 seq0 10 + 0 10 seq1 10 + 0 10 0\n10\n\nchain 50 seq0 10 + 0 10 seq2 10 + 0 10 1\n10";
+        let reader = Reader::new(&data[..]);
+        let machine = machine::Builder.try_build_from(reader)?;
+
+        let from = Coordinate::new("seq0", Strand::Positive, 1u64);
+        let to = Coordinate::new("seq0", Strand::Positive, 5u64);
+        let interval = Interval::try_new(from, to)?;
+
+        let mut results = machine.liftover(interval).unwrap();
+        assert_eq!(results.len(), 2);
+
+        // Sort by chain ID for deterministic assertions.
+        results.sort_by_key(|r| r.chain().id());
+
+        assert_eq!(results[0].chain().id(), 0);
+        assert_eq!(results[0].chain().score(), 100);
+        assert_eq!(results[0].segments().len(), 1);
+        assert_eq!(results[0].segments()[0].query().contig().as_str(), "seq1");
+
+        assert_eq!(results[1].chain().id(), 1);
+        assert_eq!(results[1].chain().score(), 50);
+        assert_eq!(results[1].segments().len(), 1);
+        assert_eq!(results[1].segments()[0].query().contig().as_str(), "seq2");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_gapped_chain_returns_multiple_segments() -> Result<(), Box<dyn std::error::Error>> {
+        // One chain with a gap: two blocks of 4, separated by a gap of
+        // 2 in both reference and query.
+        let data = b"chain 0 seq0 10 + 0 10 seq1 10 + 0 10 0\n4\t2\t2\n4";
+        let reader = Reader::new(&data[..]);
+        let machine = machine::Builder.try_build_from(reader)?;
+
+        let from = Coordinate::new("seq0", Strand::Positive, 0u64);
+        let to = Coordinate::new("seq0", Strand::Positive, 10u64);
+        let interval = Interval::try_new(from, to)?;
+
+        let results = machine.liftover(interval).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].segments().len(), 2);
+        assert_eq!(results[0].segments()[0].reference().count_entities(), 4);
+        assert_eq!(results[0].segments()[1].reference().count_entities(), 4);
 
         Ok(())
     }

--- a/src/liftover/machine/builder.rs
+++ b/src/liftover/machine/builder.rs
@@ -8,36 +8,45 @@ use omics::coordinate::Strand;
 use omics::coordinate::position::Number;
 use rust_lapper as lapper;
 
+use thiserror::Error;
+
 use crate::alignment;
+use crate::alignment::section::header::Record as Header;
 use crate::liftover;
-use crate::liftover::Machine;
-use crate::liftover::machine::ChromosomeDictionary;
-use crate::liftover::stepthrough::interval_pair::ContiguousIntervalPair;
+use super::AnnotatedPair;
+use super::ChromosomeDictionary;
+use super::Machine;
 use crate::reader;
 
 /// The inner value of the liftover lookup data structure.
-type Iv = lapper::Interval<Number, ContiguousIntervalPair>;
+type Iv = lapper::Interval<Number, AnnotatedPair>;
 
 /// An error related to building a [`Machine`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// An error reading alignment sections.
+    #[error("invalid data section: {0}")]
     InvalidSections(alignment::section::sections::Error),
 
     /// An error stepping through the liftover segments.
+    #[error("stepthrough error: {0}")]
     StepthroughError(liftover::stepthrough::Error),
-}
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::InvalidSections(err) => write!(f, "invalid data section: {err}"),
-            Error::StepthroughError(err) => write!(f, "stepthrough error: {err}"),
-        }
-    }
-}
+    /// Two chain sections share the same ID but have different headers.
+    #[error(
+        "duplicate chain id `{id}` with inconsistent headers: expected `{expected}`, found `{found}`"
+    )]
+    DuplicateChainId {
+        /// The chain ID.
+        id: usize,
 
-impl std::error::Error for Error {}
+        /// The first header encountered for this chain ID.
+        expected: Header,
+
+        /// The conflicting header encountered for this chain ID.
+        found: Header,
+    },
+}
 
 /// A [`Result`](std::result::Result) with an [`Error`].
 type Result<T> = std::result::Result<T, Error>;
@@ -65,6 +74,7 @@ impl Builder {
         T: BufRead,
     {
         let mut hm = HashMap::<Contig, Vec<Iv>>::default();
+        let mut chains = HashMap::<usize, Header>::new();
 
         let mut reference_chromosomes = ChromosomeDictionaryBuilder::default();
         let mut query_chromosomes = ChromosomeDictionaryBuilder::default();
@@ -72,7 +82,21 @@ impl Builder {
         for result in reader.sections() {
             let section = result.map_err(Error::InvalidSections)?;
 
-            let header = section.header();
+            let header = section.header().clone();
+
+            match chains.get(&header.id()) {
+                Some(existing) if *existing != header => {
+                    return Err(Error::DuplicateChainId {
+                        id: header.id(),
+                        expected: existing.clone(),
+                        found: header,
+                    });
+                }
+                _ => {
+                    chains.insert(header.id(), header.clone());
+                }
+            }
+
             query_chromosomes.update(
                 header.query_sequence().chromosome_name().to_string(),
                 header.query_sequence().chromosome_size(),
@@ -104,12 +128,15 @@ impl Builder {
                 entry.push(lapper::Interval {
                     start,
                     stop,
-                    val: pair,
+                    val: AnnotatedPair {
+                        chain: header.clone(),
+                        pair,
+                    },
                 })
             }
         }
 
-        let mut inner = HashMap::<Contig, lapper::Lapper<Number, ContiguousIntervalPair>>::new();
+        let mut inner = HashMap::<Contig, lapper::Lapper<Number, AnnotatedPair>>::new();
 
         for (k, v) in hm.into_iter() {
             inner.insert(k, lapper::Lapper::new(v));
@@ -156,5 +183,35 @@ impl ChromosomeDictionaryBuilder {
     /// Consumes `self` and returns the built [`ChromosomeDictionary`].
     fn build(self) -> ChromosomeDictionary {
         self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Reader;
+
+    use super::*;
+
+    #[test]
+    fn duplicate_chain_id_with_inconsistent_headers() {
+        // Two chains with the same ID (`0`) but different scores.
+        let data =
+            b"chain 100 seq0 10 + 0 10 seq1 10 + 0 10 0\n10\n\nchain 50 seq0 10 + 0 10 seq2 10 + 0 10 0\n10";
+        let reader = Reader::new(&data[..]);
+        let err = Builder.try_build_from(reader).unwrap_err();
+
+        assert!(
+            matches!(err, Error::DuplicateChainId { id: 0, .. }),
+            "expected DuplicateChainId error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_chain_id_with_consistent_headers_succeeds() {
+        // Two identical chain sections with the same ID—this is fine.
+        let data =
+            b"chain 100 seq0 10 + 0 10 seq1 10 + 0 10 0\n10\n\nchain 100 seq0 10 + 0 10 seq1 10 + 0 10 0\n10";
+        let reader = Reader::new(&data[..]);
+        assert!(Builder.try_build_from(reader).is_ok());
     }
 }

--- a/src/liftover/machine/builder.rs
+++ b/src/liftover/machine/builder.rs
@@ -7,15 +7,14 @@ use omics::coordinate::Contig;
 use omics::coordinate::Strand;
 use omics::coordinate::position::Number;
 use rust_lapper as lapper;
-
 use thiserror::Error;
 
-use crate::alignment;
-use crate::alignment::section::header::Record as Header;
-use crate::liftover;
 use super::AnnotatedPair;
 use super::ChromosomeDictionary;
 use super::Machine;
+use crate::alignment;
+use crate::alignment::section::header::Record as Header;
+use crate::liftover;
 use crate::reader;
 
 /// The inner value of the liftover lookup data structure.
@@ -34,7 +33,8 @@ pub enum Error {
 
     /// Two chain sections share the same ID but have different headers.
     #[error(
-        "duplicate chain id `{id}` with inconsistent headers: expected `{expected}`, found `{found}`"
+        "duplicate chain id `{id}` with inconsistent headers: expected `{expected}`, found \
+         `{found}`"
     )]
     DuplicateChainId {
         /// The chain ID.
@@ -188,9 +188,8 @@ impl ChromosomeDictionaryBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::Reader;
-
     use super::*;
+    use crate::Reader;
 
     #[test]
     fn duplicate_chain_id_with_inconsistent_headers() {

--- a/src/liftover/stepthrough.rs
+++ b/src/liftover/stepthrough.rs
@@ -8,6 +8,7 @@ use omics::coordinate;
 use omics::coordinate::interbase::Coordinate;
 use omics::coordinate::interval::interbase::Interval;
 use omics::coordinate::position::Number;
+use thiserror::Error;
 use tracing_log::log::warn;
 
 use crate::alignment::Section;
@@ -19,50 +20,30 @@ use crate::liftover::stepthrough::interval_pair::ContiguousIntervalPair;
 pub mod interval_pair;
 
 /// An error related to stepping through liftover segments.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// When stepping through the interval step through, moving the coordinates
     /// returned `None`, which indicates there was an out of bounds somewhere.
+    #[error("interval stepthrough out of bounds: moving {0} from {1} by {2}")]
     IntervalStepthroughOutOfBounds(String, Coordinate, Number),
 
     /// An interval error.
+    #[error("interval error: {0}")]
     Interval(coordinate::interval::Error),
 
     /// An error occurred when constructing a [`ContiguousIntervalPair`].
+    #[error("invalid interval pair: {0}")]
     InvalidIntervalPair(interval_pair::Error),
 
     /// The data section does not cumulative add up the specified end
     /// coordinates. This indicates a malformed data section.
+    #[error("misaligned data section, which indicates a malformed chain file")]
     MisalignedDataSection,
 
     /// A sequence error.
+    #[error("sequence error: {0}")]
     Sequence(sequence::Error),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::IntervalStepthroughOutOfBounds(name, coordinate, magnitude) => {
-                write!(
-                    f,
-                    "interval stepthrough out of bounds: moving {name} from {coordinate} by \
-                     {magnitude}"
-                )
-            }
-            Error::Interval(err) => write!(f, "interval error: {err}"),
-            Error::InvalidIntervalPair(err) => {
-                write!(f, "invalid interval pair: {err}")
-            }
-            Error::MisalignedDataSection => write!(
-                f,
-                "misaligned data section, which indicates a malformed chain file"
-            ),
-            Error::Sequence(err) => write!(f, "sequence error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// The core struct using for stepping through contiguous liftover segments.
 pub struct StepThroughWithData {

--- a/src/liftover/stepthrough/interval_pair.rs
+++ b/src/liftover/stepthrough/interval_pair.rs
@@ -3,32 +3,22 @@
 use omics::coordinate;
 use omics::coordinate::interbase::Coordinate;
 use omics::coordinate::interval::interbase::Interval;
+use thiserror::Error;
 
 /// An error related to constructing a contiguous interval pair.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// The two intervals don't have the same size. As such, they can't
     /// contiguously map to one another.
+    #[error(
+        "reference interval entity count ({0}) doesn't match query interval entity count ({1})"
+    )]
     EntityCountsDontMatch(u64, u64),
 
     /// An interval error.
+    #[error("interval error: {0}")]
     Interval(coordinate::interval::Error),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::EntityCountsDontMatch(reference, query) => write!(
-                f,
-                "reference interval entity count ({reference}) doesn't match query interval \
-                 entity count ({query})"
-            ),
-            Error::Interval(err) => write!(f, "interval error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A utility struct which contains a linearly mapped segment of both the
 /// reference and the query sequence.

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,5 +1,7 @@
 //! A line within a chain file.
 
+use thiserror::Error;
+
 use crate::alignment::section::data;
 use crate::alignment::section::data::Record as AlignmentDataRecord;
 use crate::alignment::section::header;
@@ -7,9 +9,10 @@ use crate::alignment::section::header::HEADER_PREFIX;
 use crate::alignment::section::header::Record as HeaderRecord;
 
 /// An error associated with parsing the chain file.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// An invalid header record.
+    #[error("invalid header record: {inner}\n\nline: `{line}`")]
     InvalidHeaderRecord {
         /// The inner error.
         inner: header::Error,
@@ -19,6 +22,7 @@ pub enum Error {
     },
 
     /// An invalid alignment data record.
+    #[error("invalid alignment data record: {inner}\n\nline: `{line}`")]
     InvalidAlignmentDataRecord {
         /// The inner error.
         inner: data::Error,
@@ -27,24 +31,6 @@ pub enum Error {
         line: String,
     },
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::InvalidHeaderRecord { inner, line } => {
-                write!(f, "invalid header record: {inner}\n\nline: `{line}`")
-            }
-            Error::InvalidAlignmentDataRecord { inner, line } => {
-                write!(
-                    f,
-                    "invalid alignment data record: {inner}\n\nline: `{line}`"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A line within a chain file.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,6 +4,8 @@ use std::io::BufRead;
 use std::io::{self};
 use std::iter;
 
+use thiserror::Error;
+
 use crate::Line;
 use crate::alignment::section::Sections;
 use crate::line;
@@ -15,25 +17,16 @@ const NEW_LINE: char = '\n';
 const CARRIAGE_RETURN: char = '\r';
 
 /// An error related to a [`Reader`].
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     /// An I/O error.
+    #[error("i/o error: {0}")]
     Io(io::Error),
 
     /// A line error.
+    #[error("line error: {0}")]
     Line(line::Error),
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Io(err) => write!(f, "i/o error: {err}"),
-            Error::Line(err) => write!(f, "line error: {err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// A chain file reader.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Previously, `Machine::liftover()` returned a flat list of `ContiguousIntervalPair`s with no information about which chain each segment originated from. This made it impossible to distinguish between segments from different chains covering the same region (ambiguous mapping) and segments from the same chain separated by a gap (straddle).

`Machine::liftover()` now returns `Vec<LiftoverResult>`, where each `LiftoverResult` groups the segments from a single chain together with the full chain header. This lets callers trivially distinguish ambiguous mappings (`results.len() > 1`) from straddle splits (`results[0].segments().len() > 1`).

The builder also now validates at build time that no two chain sections share the same ID with inconsistent headers, surfacing a `DuplicateChainId` error rather than silently dropping metadata at query time.

All hand-written `Display` and `std::error::Error` impls across the crate have been replaced with `thiserror` derives. The `compare-crossmap` binary now selects the highest-scoring chain when multiple chains overlap a single-position query (matching CrossMap's behavior) and logs timing information for both tools. MSRV has been bumped to 1.85.0.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] You have added any relevant tags to the pull request.
- [x] Your code builds clean without any errors or warnings (use `cargo test` and `cargo clippy`).
- [x] You have added tests (when appropriate).
- [ ] You have updated the wiki (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry in the `CHANGELOG.md`.