### PR TITLE
feat: optimizes liftover performance and bumps `omics` to `v0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
 - MSRV bumped to 1.85.0
   ([#9](https://github.com/stjude-rust-labs/chainfile/pull/9)).
+- Bumped `omics` from `v0.2.0` to `v0.4.0`, adopting `Arc<str>`-backed
+  `Contig` for `O(1)` clones, the new `Contig` validation API, and
+  in-place coordinate move methods
+  ([#10](https://github.com/stjude-rust-labs/chainfile/pull/10)).
+- Optimized liftover hot paths: stepthrough now uses in-place
+  `move_forward`/`move_backward` (cutting per-step clones from 8–12 to 4),
+  lapper results are filtered by strand before cloning, `Contig` creation is
+  hoisted out of the inner loop in the builder, and data record parsing uses
+  `splitn` instead of `split().collect()`
+  ([#10](https://github.com/stjude-rust-labs/chainfile/pull/10)).
+- Refactored `AnnotatedPair` to store `chain_id: usize` instead of a full
+  `Header`, with a `HashMap<usize, Header>` side table on `Machine`
+  ([#10](https://github.com/stjude-rust-labs/chainfile/pull/10)).
+- Liftover grouping replaced `HashMap` with a sort-and-linear-scan over a
+  flat `Vec`
+  ([#10](https://github.com/stjude-rust-labs/chainfile/pull/10)).
+- `Machine::liftover()` now returns results in deterministic order: sorted by
+  score descending (best chain first) then chain ID ascending, with segments
+  sorted by reference start position
+  ([#10](https://github.com/stjude-rust-labs/chainfile/pull/10)).
+- Added Criterion benchmarks for single-position liftover, interval liftover,
+  machine building, query-only throughput, and end-to-end throughput with
+  fixed-seed RNG for reproducibility
+  ([#10](https://github.com/stjude-rust-labs/chainfile/pull/10)).
 
 ## 0.3.0 - 01-03-2025
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.85.0"
 
 [dependencies]
-omics = { version = "0.2.0", features = ["coordinate", "position-u64"] }
+omics = { version = "0.4.0", features = ["coordinate", "position-u64"] }
 anyhow = { version = "1.0.89", optional = true }
 clap = { version = "4.5.20", features = ["derive"], optional = true }
 clap-verbosity-flag = { version = "2.2.2", optional = true }
@@ -31,7 +31,9 @@ tracing-subscriber = { version = "0.3.18", features = [
 weighted_rand = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
 noodles = { version = "0.87.0", features = ["core", "fasta"] }
+rand = "0.8.5"
 tabled = { version = "0.16.0" }
 
 [features]
@@ -51,3 +53,15 @@ binaries = [
 [[bin]]
 name = "compare-crossmap"
 required-features = ["binaries"]
+
+[[bench]]
+name = "machine"
+harness = false
+
+[[bench]]
+name = "liftover"
+harness = false
+
+[[bench]]
+name = "end_to_end"
+harness = false

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -1,0 +1,103 @@
+mod support;
+
+use std::hint::black_box;
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use omics::coordinate::Contig;
+use omics::coordinate::Strand;
+use omics::coordinate::interbase::Coordinate;
+use omics::coordinate::interval::interbase::Interval;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use support::generate_chain_data;
+
+const NUM_CONTIGS: usize = 25;
+const BLOCKS_PER_CONTIG: usize = 1_000;
+const BLOCK_SIZE: u64 = 1_000;
+const GAP_SIZE: u64 = 100;
+const SEED: u64 = 42;
+
+fn total_contig_size() -> u64 {
+    BLOCKS_PER_CONTIG as u64 * BLOCK_SIZE + (BLOCKS_PER_CONTIG as u64 - 1) * GAP_SIZE
+}
+
+fn generate_query_intervals(count: usize) -> Vec<Interval> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let total = total_contig_size();
+
+    (0..count)
+        .map(|_| {
+            let contig_idx = rng.gen_range(1..=NUM_CONTIGS);
+            let contig = Contig::new_unchecked(format!("chr{contig_idx}"));
+            let pos = rng.gen_range(0..total - 1);
+
+            let from = Coordinate::new(contig.clone(), Strand::Positive, pos);
+            let to = Coordinate::new(contig, Strand::Positive, pos + 1);
+            Interval::try_new(from, to).unwrap()
+        })
+        .collect()
+}
+
+fn bench_query_only(c: &mut Criterion) {
+    let data = generate_chain_data(NUM_CONTIGS, BLOCKS_PER_CONTIG, BLOCK_SIZE, GAP_SIZE);
+    let reader = chainfile::Reader::new(&data[..]);
+    let machine = chainfile::liftover::machine::Builder
+        .try_build_from(reader)
+        .unwrap();
+
+    let mut group = c.benchmark_group("query_only");
+
+    for num_queries in [1_000, 10_000, 100_000] {
+        let intervals = generate_query_intervals(num_queries);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{num_queries}_queries")),
+            &intervals,
+            |b, intervals| {
+                b.iter(|| {
+                    for interval in intervals {
+                        black_box(machine.liftover(interval.clone()));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_end_to_end(c: &mut Criterion) {
+    let data = generate_chain_data(NUM_CONTIGS, BLOCKS_PER_CONTIG, BLOCK_SIZE, GAP_SIZE);
+
+    let mut group = c.benchmark_group("end_to_end");
+
+    for num_queries in [1_000, 10_000, 100_000] {
+        let intervals = generate_query_intervals(num_queries);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{num_queries}_queries")),
+            &intervals,
+            |b, intervals| {
+                b.iter(|| {
+                    let reader = chainfile::Reader::new(&data[..]);
+                    let machine = chainfile::liftover::machine::Builder
+                        .try_build_from(reader)
+                        .unwrap();
+
+                    for interval in intervals {
+                        black_box(machine.liftover(interval.clone()));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_query_only, bench_end_to_end);
+criterion_main!(benches);

--- a/benches/liftover.rs
+++ b/benches/liftover.rs
@@ -1,0 +1,127 @@
+mod support;
+
+use std::hint::black_box;
+
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use omics::coordinate::Contig;
+use omics::coordinate::Strand;
+use omics::coordinate::interbase::Coordinate;
+use omics::coordinate::interval::interbase::Interval;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use support::generate_chain_data;
+
+const NUM_CONTIGS: usize = 25;
+const BLOCKS_PER_CONTIG: usize = 1_000;
+const BLOCK_SIZE: u64 = 1_000;
+const GAP_SIZE: u64 = 100;
+const SEED: u64 = 42;
+const NUM_QUERIES: usize = 1_000;
+
+fn build_machine() -> chainfile::liftover::Machine {
+    let data = generate_chain_data(NUM_CONTIGS, BLOCKS_PER_CONTIG, BLOCK_SIZE, GAP_SIZE);
+    let reader = chainfile::Reader::new(&data[..]);
+    chainfile::liftover::machine::Builder
+        .try_build_from(reader)
+        .unwrap()
+}
+
+fn total_contig_size() -> u64 {
+    BLOCKS_PER_CONTIG as u64 * BLOCK_SIZE + (BLOCKS_PER_CONTIG as u64 - 1) * GAP_SIZE
+}
+
+fn generate_single_position_intervals(count: usize) -> Vec<Interval> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let total = total_contig_size();
+
+    (0..count)
+        .map(|_| {
+            let contig_idx = rng.gen_range(1..=NUM_CONTIGS);
+            let contig = Contig::new_unchecked(format!("chr{contig_idx}"));
+            let pos = rng.gen_range(0..total - 1);
+
+            let from = Coordinate::new(contig.clone(), Strand::Positive, pos);
+            let to = Coordinate::new(contig, Strand::Positive, pos + 1);
+            Interval::try_new(from, to).unwrap()
+        })
+        .collect()
+}
+
+fn generate_small_intervals(count: usize) -> Vec<Interval> {
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    (0..count)
+        .map(|_| {
+            let contig_idx = rng.gen_range(1..=NUM_CONTIGS);
+            let contig = Contig::new_unchecked(format!("chr{contig_idx}"));
+            let pos = rng.gen_range(0..BLOCK_SIZE - 100);
+
+            let from = Coordinate::new(contig.clone(), Strand::Positive, pos);
+            let to = Coordinate::new(contig, Strand::Positive, pos + 100);
+            Interval::try_new(from, to).unwrap()
+        })
+        .collect()
+}
+
+fn bench_single_position_hit(c: &mut Criterion) {
+    let machine = build_machine();
+    let intervals = generate_single_position_intervals(NUM_QUERIES);
+
+    c.bench_function("liftover/single_position_hit", |b| {
+        b.iter(|| {
+            for interval in &intervals {
+                black_box(machine.liftover(interval.clone()));
+            }
+        });
+    });
+}
+
+fn bench_single_position_miss(c: &mut Criterion) {
+    let machine = build_machine();
+    let contig = Contig::new_unchecked("nonexistent");
+    let from = Coordinate::new(contig.clone(), Strand::Positive, 0u64);
+    let to = Coordinate::new(contig, Strand::Positive, 1u64);
+    let interval = Interval::try_new(from, to).unwrap();
+
+    c.bench_function("liftover/single_position_miss", |b| {
+        b.iter(|| black_box(machine.liftover(interval.clone())));
+    });
+}
+
+fn bench_small_interval(c: &mut Criterion) {
+    let machine = build_machine();
+    let intervals = generate_small_intervals(NUM_QUERIES);
+
+    c.bench_function("liftover/small_interval", |b| {
+        b.iter(|| {
+            for interval in &intervals {
+                black_box(machine.liftover(interval.clone()));
+            }
+        });
+    });
+}
+
+fn bench_large_interval_straddling_gaps(c: &mut Criterion) {
+    let machine = build_machine();
+    let total = total_contig_size();
+    let contig = Contig::new_unchecked("chr1");
+    let from = Coordinate::new(contig.clone(), Strand::Positive, 0u64);
+    let to = Coordinate::new(contig, Strand::Positive, total);
+    let interval = Interval::try_new(from, to).unwrap();
+
+    c.bench_function("liftover/large_interval_straddling_gaps", |b| {
+        b.iter(|| black_box(machine.liftover(interval.clone())));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_single_position_hit,
+    bench_single_position_miss,
+    bench_small_interval,
+    bench_large_interval_straddling_gaps
+);
+criterion_main!(benches);

--- a/benches/machine.rs
+++ b/benches/machine.rs
@@ -1,0 +1,39 @@
+mod support;
+
+use std::hint::black_box;
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use support::generate_chain_data;
+
+fn bench_machine_building(c: &mut Criterion) {
+    let mut group = c.benchmark_group("machine_building");
+
+    let configs = [
+        ("small", 5, 100, 500, 50),
+        ("medium", 25, 1_000, 1_000, 100),
+        ("large", 25, 10_000, 1_000, 100),
+    ];
+
+    for (label, num_contigs, blocks, block_size, gap_size) in configs {
+        let data = generate_chain_data(num_contigs, blocks, block_size, gap_size);
+
+        group.bench_with_input(BenchmarkId::from_parameter(label), &data, |b, data| {
+            b.iter(|| {
+                let reader = chainfile::Reader::new(&data[..]);
+                black_box(
+                    chainfile::liftover::machine::Builder
+                        .try_build_from(reader)
+                        .unwrap(),
+                )
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_machine_building);
+criterion_main!(benches);

--- a/benches/support.rs
+++ b/benches/support.rs
@@ -1,0 +1,44 @@
+use std::fmt::Write;
+
+/// Generates synthetic chain file data in memory.
+///
+/// Each contig gets `blocks_per_contig` aligned blocks of `block_size` bases,
+/// separated by gaps of `gap_size` in both reference and query.
+pub fn generate_chain_data(
+    num_contigs: usize,
+    blocks_per_contig: usize,
+    block_size: u64,
+    gap_size: u64,
+) -> Vec<u8> {
+    let mut buf = String::new();
+
+    for contig_idx in 0..num_contigs {
+        let ref_name = format!("chr{}", contig_idx + 1);
+        let query_name = format!("qchr{}", contig_idx + 1);
+
+        let total_ref_size =
+            blocks_per_contig as u64 * block_size + (blocks_per_contig as u64 - 1) * gap_size;
+        let total_query_size = total_ref_size;
+
+        writeln!(
+            buf,
+            "chain 100 {ref_name} {total_ref_size} + 0 {total_ref_size} {query_name} \
+             {total_query_size} + 0 {total_query_size} {contig_idx}"
+        )
+        .unwrap();
+
+        for block_idx in 0..blocks_per_contig {
+            if block_idx < blocks_per_contig - 1 {
+                writeln!(buf, "{block_size}\t{gap_size}\t{gap_size}").unwrap();
+            } else {
+                writeln!(buf, "{block_size}").unwrap();
+            }
+        }
+
+        if contig_idx < num_contigs - 1 {
+            writeln!(buf).unwrap();
+        }
+    }
+
+    buf.into_bytes()
+}

--- a/examples/chain_check.rs
+++ b/examples/chain_check.rs
@@ -30,6 +30,7 @@ use chainfile as chain;
 use flate2::read::GzDecoder;
 use noodles::fasta;
 use noodles::fasta::record::Sequence;
+use omics::coordinate::Contig;
 use omics::coordinate::Strand;
 use omics::coordinate::interbase::Coordinate;
 use omics::coordinate::interval::interbase::Interval;
@@ -82,9 +83,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .iter()
         .map(|(name, reference_sequence)| {
             Interval::try_new(
-                Coordinate::new(name.as_str(), Strand::Positive, 0_u64),
                 Coordinate::new(
-                    name.as_str(),
+                    Contig::new_unchecked(name.as_str()),
+                    Strand::Positive,
+                    0_u64,
+                ),
+                Coordinate::new(
+                    Contig::new_unchecked(name.as_str()),
                     Strand::Positive,
                     reference_sequence.len() as u64,
                 ),

--- a/src/alignment/section/data.rs
+++ b/src/alignment/section/data.rs
@@ -214,33 +214,34 @@ impl FromStr for Record {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let parts = s.split(ALIGNMENT_DATA_DELIMITER).collect::<Vec<_>>();
+        let mut parts = s.splitn(4, ALIGNMENT_DATA_DELIMITER);
 
-        let kind = match parts.len() {
-            NUM_ALIGNMENT_DATA_FIELDS_TERMINATING => Kind::Terminating,
-            NUM_ALIGNMENT_DATA_FIELDS_NONTERMINATING => Kind::NonTerminating,
-            _ => {
-                return Err(Error::Parse(ParseError::IncorrectNumberOfFields(
-                    parts.len(),
-                )));
-            }
-        };
-
-        let size = parts[0]
+        let size_str = parts
+            .next()
+            .ok_or(Error::Parse(ParseError::IncorrectNumberOfFields(0)))?;
+        let size = size_str
             .parse()
             .map_err(|err| Error::Parse(ParseError::InvalidSize(err)))?;
 
-        let (dt, dq) = match kind {
-            Kind::NonTerminating => {
-                let dt = parts[1]
+        let (dt, dq, kind) = match parts.next() {
+            None => (None, None, Kind::Terminating),
+            Some(dt_str) => {
+                let dq_str = parts
+                    .next()
+                    .ok_or(Error::Parse(ParseError::IncorrectNumberOfFields(2)))?;
+
+                if parts.next().is_some() {
+                    return Err(Error::Parse(ParseError::IncorrectNumberOfFields(4)));
+                }
+
+                let dt = dt_str
                     .parse()
                     .map_err(|err| Error::Parse(ParseError::InvalidDt(err)))?;
-                let dq = parts[2]
+                let dq = dq_str
                     .parse()
                     .map_err(|err| Error::Parse(ParseError::InvalidDq(err)))?;
-                (Some(dt), Some(dq))
+                (Some(dt), Some(dq), Kind::NonTerminating)
             }
-            Kind::Terminating => (None, None),
         };
 
         Record::try_new(size, dt, dq, kind)

--- a/src/alignment/section/header/sequence.rs
+++ b/src/alignment/section/header/sequence.rs
@@ -105,7 +105,7 @@ impl Sequence {
         alignment_start: &str,
         alignment_end: &str,
     ) -> Result<Self> {
-        let chromosome_name = chromosome_name.into();
+        let chromosome_name = Contig::new_unchecked(chromosome_name);
 
         let chromosome_size = chromosome_size
             .parse()
@@ -269,8 +269,9 @@ impl Sequence {
             ),
         };
 
-        let start = Coordinate::new(self.chromosome_name(), self.strand(), start_pos);
-        let end = Coordinate::new(self.chromosome_name(), self.strand(), end_pos);
+        let contig = Contig::new_unchecked(self.chromosome_name());
+        let start = Coordinate::new(contig.clone(), self.strand(), start_pos);
+        let end = Coordinate::new(contig, self.strand(), end_pos);
 
         Interval::try_new(start, end).map_err(Error::Interval)
     }

--- a/src/bin/compare-crossmap.rs
+++ b/src/bin/compare-crossmap.rs
@@ -32,6 +32,7 @@ use chainfile::liftover;
 use clap::Parser;
 use clap_verbosity_flag::Verbosity;
 use flate2::read::GzDecoder;
+use omics::coordinate::Contig;
 use omics::coordinate::Coordinate;
 use omics::coordinate::Interval;
 use omics::coordinate::Strand;
@@ -174,7 +175,7 @@ impl BedEntry {
     /// Turns the BED entry back into an interbase coordinate.
     fn into_coordinate(self, strand: Strand) -> Coordinate<Interbase> {
         omics::coordinate::Coordinate::<Interbase>::new(
-            self.contig.as_str(),
+            Contig::new_unchecked(self.contig.as_str()),
             strand,
             self.start as Number,
         )
@@ -624,17 +625,30 @@ fn throw(args: &Args) -> Result<()> {
     let chainfile_liftover_start = std::time::Instant::now();
 
     for (from, crossmap_result) in crossmap_results {
-        let start =
-            Coordinate::<Interbase>::new(from.contig.as_str(), Strand::Positive, from.start);
-        let end = Coordinate::<Interbase>::new(from.contig.as_str(), Strand::Positive, from.end);
+        let start = Coordinate::<Interbase>::new(
+            Contig::new_unchecked(from.contig.as_str()),
+            Strand::Positive,
+            from.start,
+        );
+        let end = Coordinate::<Interbase>::new(
+            Contig::new_unchecked(from.contig.as_str()),
+            Strand::Positive,
+            from.end,
+        );
         let from_interval =
             Interval::try_new(start, end).expect("interval to be able to be created");
 
         let chainfile_result = machine
             .liftover(from_interval)
             .and_then(|results| {
-                // Select the result from the highest-scoring chain.
-                let result = results.into_iter().max_by_key(|r| r.chain().score())?;
+                // Select the result from the highest-scoring chain. Ties are
+                // broken by smallest chain ID for determinism.
+                let result = results.into_iter().max_by(|a, b| {
+                    a.chain()
+                        .score()
+                        .cmp(&b.chain().score())
+                        .then_with(|| b.chain().id().cmp(&a.chain().id()))
+                })?;
 
                 let mut segments = result.into_segments();
                 assert!(
@@ -664,7 +678,7 @@ fn throw(args: &Args) -> Result<()> {
                 let (contig, _, position) = query.into_start().into_parts();
 
                 Some(LiftoverResult::Mapped(BedEntry::new_single_position(
-                    contig.into_inner(),
+                    contig.to_string(),
                     position.get() as Number,
                 )))
             })

--- a/src/liftover/machine.rs
+++ b/src/liftover/machine.rs
@@ -18,11 +18,11 @@ pub use builder::Builder;
 /// A dictionary of chromosome names and their size.
 pub type ChromosomeDictionary = HashMap<String, Number>;
 
-/// A mapping segment annotated with the chain from which it originated.
+/// A mapping segment annotated with the chain ID from which it originated.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct AnnotatedPair {
-    /// The chain from which this segment originated.
-    chain: Header,
+    /// The chain ID from which this segment originated.
+    chain_id: usize,
 
     /// The mapping segment.
     pair: ContiguousIntervalPair,
@@ -70,6 +70,9 @@ pub struct Machine {
     /// in the query genome for each contig in the reference genome.
     inner: HashMap<Contig, lapper::Lapper<Number, AnnotatedPair>>,
 
+    /// A lookup table from chain ID to the chain header.
+    chains: HashMap<usize, Header>,
+
     /// The reference chromosome corpus.
     reference_chromosomes: ChromosomeDictionary,
 
@@ -95,56 +98,84 @@ impl Machine {
     /// Results are grouped by the chain from which each mapping segment
     /// originated. Each [`LiftoverResult`] contains one or more contiguous
     /// segments from a single chain, along with the chain's header.
+    ///
+    /// The returned `Vec<LiftoverResult>` is sorted by score descending
+    /// (best chain first), with chain ID ascending as a tiebreaker. Within
+    /// each result, `segments()` are sorted by reference interval start
+    /// position ascending, with end position as a tiebreaker.
     pub fn liftover(&self, interval: Interval) -> Option<Vec<LiftoverResult>> {
         let entry = self.inner.get(interval.contig())?;
 
         let (start, stop) = match interval.strand() {
-            Strand::Positive => {
-                let start = interval.start().position().get();
-                let end = interval.end().position().get();
-
-                (start, end)
-            }
-            Strand::Negative => {
-                let start = interval.end().position().get();
-                let end = interval.start().position().get();
-
-                (start, end)
-            }
+            Strand::Positive => (
+                interval.start().position().get(),
+                interval.end().position().get(),
+            ),
+            Strand::Negative => (
+                interval.end().position().get(),
+                interval.start().position().get(),
+            ),
         };
 
         let strand = interval.strand();
 
-        let clamped = entry
-            .find(start, stop)
-            .map(|e| e.val.clone())
-            .filter(|ap| ap.pair.reference().strand() == strand)
-            .map(|ap| {
-                // SAFETY: the lapper guarantees that `ap.pair` overlaps
-                // `interval`, so `clamp()` will always succeed.
-                let pair = ap.pair.clamp(interval.clone()).unwrap();
-                (pair, ap.chain)
-            })
-            .collect::<Vec<_>>();
+        let mut hits = Vec::<(usize, ContiguousIntervalPair)>::new();
 
-        if clamped.is_empty() {
+        for e in entry.find(start, stop) {
+            if e.val.pair.reference().strand() != strand {
+                continue;
+            }
+
+            // SAFETY: the lapper guarantees that `e.val.pair` overlaps
+            // `interval`, so `clamp()` will always succeed.
+            let pair = e.val.pair.clone().clamp(interval.clone()).unwrap();
+            hits.push((e.val.chain_id, pair));
+        }
+
+        if hits.is_empty() {
             return None;
         }
 
-        let mut groups = HashMap::<usize, (Header, Vec<ContiguousIntervalPair>)>::new();
+        // Sort by chain ID so that consecutive entries with the same ID are
+        // adjacent, then group them.
+        hits.sort_by_key(|(id, _)| *id);
 
-        for (pair, chain) in clamped {
-            groups
-                .entry(chain.id())
-                .or_insert_with(|| (chain, Vec::new()))
-                .1
-                .push(pair);
+        let mut results = Vec::<LiftoverResult>::new();
+
+        for (chain_id, pair) in hits {
+            match results.last_mut() {
+                Some(last) if last.chain().id() == chain_id => {
+                    last.segments.push(pair);
+                }
+                _ => {
+                    let chain = self.chains[&chain_id].clone();
+                    results.push(LiftoverResult {
+                        chain,
+                        segments: vec![pair],
+                    });
+                }
+            }
         }
 
-        let results = groups
-            .into_values()
-            .map(|(chain, segments)| LiftoverResult { chain, segments })
-            .collect::<Vec<_>>();
+        // Within each chain group, ensure segments are sorted by reference
+        // start position.
+        for result in &mut results {
+            result.segments.sort_by(|a, b| {
+                a.reference()
+                    .start()
+                    .cmp(b.reference().start())
+                    .then_with(|| a.reference().end().cmp(b.reference().end()))
+            });
+        }
+
+        // Sort results by score descending so the best chain comes first,
+        // with chain ID ascending as a tiebreaker.
+        results.sort_by(|a, b| {
+            b.chain()
+                .score()
+                .cmp(&a.chain().score())
+                .then_with(|| a.chain().id().cmp(&b.chain().id()))
+        });
 
         Some(results)
     }
@@ -152,6 +183,7 @@ impl Machine {
 
 #[cfg(test)]
 mod tests {
+    use omics::coordinate::Contig;
     use omics::coordinate::interbase::Coordinate;
     use omics::coordinate::position::interbase::Position;
 
@@ -165,8 +197,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Positive, 1u64);
-        let to = Coordinate::new("seq0", Strand::Positive, 7u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 1u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 7u64);
 
         let interval = Interval::try_new(from, to)?;
         let results = machine.liftover(interval).unwrap();
@@ -197,8 +229,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Negative, 7u64);
-        let to = Coordinate::new("seq0", Strand::Negative, 1u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 7u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 1u64);
 
         let interval = Interval::try_new(from, to)?;
         let results = machine.liftover(interval).unwrap();
@@ -230,8 +262,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Positive, 1u64);
-        let to = Coordinate::new("seq0", Strand::Positive, 7u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 1u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 7u64);
 
         let interval = Interval::try_new(from, to)?;
         let results = machine.liftover(interval).unwrap();
@@ -263,8 +295,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Negative, 7u64);
-        let to = Coordinate::new("seq0", Strand::Negative, 1u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 7u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 1u64);
 
         let interval = Interval::try_new(from, to)?;
         let results = machine.liftover(interval).unwrap();
@@ -296,8 +328,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Positive, 1u64);
-        let to = Coordinate::new("seq0", Strand::Positive, 7u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 1u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 7u64);
 
         let interval = Interval::try_new(from, to)?;
         let results = machine.liftover(interval);
@@ -314,8 +346,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Negative, 7u64);
-        let to = Coordinate::new("seq0", Strand::Negative, 1u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 7u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 1u64);
 
         let interval = Interval::try_new(from, to)?;
         let results = machine.liftover(interval);
@@ -334,23 +366,21 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Positive, 1u64);
-        let to = Coordinate::new("seq0", Strand::Positive, 5u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 1u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 5u64);
         let interval = Interval::try_new(from, to)?;
 
-        let mut results = machine.liftover(interval).unwrap();
+        let results = machine.liftover(interval).unwrap();
         assert_eq!(results.len(), 2);
 
-        // Sort by chain ID for deterministic assertions.
-        results.sort_by_key(|r| r.chain().id());
-
-        assert_eq!(results[0].chain().id(), 0);
+        // Results are sorted by score descending.
         assert_eq!(results[0].chain().score(), 100);
+        assert_eq!(results[0].chain().id(), 0);
         assert_eq!(results[0].segments().len(), 1);
         assert_eq!(results[0].segments()[0].query().contig().as_str(), "seq1");
 
-        assert_eq!(results[1].chain().id(), 1);
         assert_eq!(results[1].chain().score(), 50);
+        assert_eq!(results[1].chain().id(), 1);
         assert_eq!(results[1].segments().len(), 1);
         assert_eq!(results[1].segments()[0].query().contig().as_str(), "seq2");
 
@@ -365,8 +395,8 @@ mod tests {
         let reader = Reader::new(&data[..]);
         let machine = machine::Builder.try_build_from(reader)?;
 
-        let from = Coordinate::new("seq0", Strand::Positive, 0u64);
-        let to = Coordinate::new("seq0", Strand::Positive, 10u64);
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 0u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 10u64);
         let interval = Interval::try_new(from, to)?;
 
         let results = machine.liftover(interval).unwrap();
@@ -374,6 +404,62 @@ mod tests {
         assert_eq!(results[0].segments().len(), 2);
         assert_eq!(results[0].segments()[0].reference().count_entities(), 4);
         assert_eq!(results[0].segments()[1].reference().count_entities(), 4);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_liftover_ordering_is_deterministic() -> Result<(), Box<dyn std::error::Error>> {
+        // Three chains with IDs 2, 0, 1 (intentionally out of order in the
+        // input) covering the same region on `seq0`.
+        let data = b"chain 30 seq0 10 + 0 10 seq3 10 + 0 10 2\n10\n\n\
+                      chain 100 seq0 10 + 0 10 seq1 10 + 0 10 0\n10\n\n\
+                      chain 50 seq0 10 + 0 10 seq2 10 + 0 10 1\n10";
+        let reader = Reader::new(&data[..]);
+        let machine = machine::Builder.try_build_from(reader)?;
+
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 0u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 10u64);
+        let interval = Interval::try_new(from, to)?;
+
+        // Run liftover multiple times and verify ordering is stable.
+        for _ in 0..10 {
+            let results = machine.liftover(interval.clone()).unwrap();
+            assert_eq!(results.len(), 3);
+
+            // Results must be sorted by score descending.
+            assert_eq!(results[0].chain().score(), 100);
+            assert_eq!(results[1].chain().score(), 50);
+            assert_eq!(results[2].chain().score(), 30);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_segments_ordered_by_reference_position() -> Result<(), Box<dyn std::error::Error>> {
+        // One chain with three blocks separated by gaps, ensuring segments
+        // come back in reference-position order. Layout: 5 + gap(2,2) + 5 +
+        // gap(2,2) + 6 = 20 reference bases.
+        let data = b"chain 0 seq0 20 + 0 20 seq1 20 + 0 20 0\n5\t2\t2\n5\t2\t2\n6";
+        let reader = Reader::new(&data[..]);
+        let machine = machine::Builder.try_build_from(reader)?;
+
+        let from = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 0u64);
+        let to = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 20u64);
+        let interval = Interval::try_new(from, to)?;
+
+        let results = machine.liftover(interval).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].segments().len(), 3);
+
+        // Segments must be sorted by reference start position.
+        let starts: Vec<_> = results[0]
+            .segments()
+            .iter()
+            .map(|s| s.reference().start().position().get())
+            .collect();
+        assert_eq!(starts, vec![0, 7, 14]);
 
         Ok(())
     }

--- a/src/liftover/machine/builder.rs
+++ b/src/liftover/machine/builder.rs
@@ -1,6 +1,7 @@
 //! A builder for a [`Machine`].
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::io::BufRead;
 
 use omics::coordinate::Contig;
@@ -84,16 +85,18 @@ impl Builder {
 
             let header = section.header().clone();
 
-            match chains.get(&header.id()) {
-                Some(existing) if *existing != header => {
-                    return Err(Error::DuplicateChainId {
-                        id: header.id(),
-                        expected: existing.clone(),
-                        found: header,
-                    });
+            match chains.entry(header.id()) {
+                Entry::Occupied(e) => {
+                    if *e.get() != header {
+                        return Err(Error::DuplicateChainId {
+                            id: header.id(),
+                            expected: e.get().clone(),
+                            found: header,
+                        });
+                    }
                 }
-                _ => {
-                    chains.insert(header.id(), header.clone());
+                Entry::Vacant(e) => {
+                    e.insert(header.clone());
                 }
             }
 
@@ -106,9 +109,11 @@ impl Builder {
                 header.reference_sequence().chromosome_size(),
             );
 
+            let contig = Contig::new_unchecked(header.reference_sequence().chromosome_name());
+            let entry = hm.entry(contig).or_default();
+
             for pair_result in section.stepthrough().map_err(Error::StepthroughError)? {
                 let pair = pair_result.map_err(Error::StepthroughError)?;
-                let entry = hm.entry(pair.reference().contig().clone()).or_default();
 
                 let (start, stop) = match pair.reference().strand() {
                     Strand::Positive => {
@@ -129,7 +134,7 @@ impl Builder {
                     start,
                     stop,
                     val: AnnotatedPair {
-                        chain: header.clone(),
+                        chain_id: header.id(),
                         pair,
                     },
                 })
@@ -147,6 +152,7 @@ impl Builder {
 
         Ok(Machine {
             inner,
+            chains,
             reference_chromosomes,
             query_chromosomes,
         })

--- a/src/liftover/stepthrough.rs
+++ b/src/liftover/stepthrough.rs
@@ -143,82 +143,58 @@ impl Iterator for StepThroughWithData {
                 Err(e) => return Some(Err(e)),
             },
         };
-        // (1) Calculate the coordinates for the reference interval.
-        // (a) Set the reference start to point to the current reference pointer.
+        // (1) Capture reference start, then advance pointer by chunk size.
         let reference_start = self.reference_pointer.clone();
 
-        // (b) Push forward the reference pointer by the amount specified in the chunk.
-        self.reference_pointer = match self.reference_pointer.clone().move_forward(chunk.size()) {
-            Some(pointer) => pointer,
-            None => {
-                return Some(Err(Error::IntervalStepthroughOutOfBounds(
-                    String::from("reference forward by chunk size"),
-                    self.reference_pointer.clone(),
-                    chunk.size(),
-                )));
-            }
-        };
+        if !self.reference_pointer.move_forward(chunk.size()) {
+            return Some(Err(Error::IntervalStepthroughOutOfBounds(
+                String::from("reference forward by chunk size"),
+                self.reference_pointer.clone(),
+                chunk.size(),
+            )));
+        }
 
-        // (c) Set the reference end to point to the current reference pointer.
         let reference_end = self.reference_pointer.clone();
-
-        // (d) Create the reference interval.
         let reference = match Interval::try_new(reference_start, reference_end) {
             Ok(interval) => interval,
             Err(err) => return Some(Err(Error::Interval(err))),
         };
 
-        // (2) Calculate the coordinates for the query interval.
-        // (a) Set the query start to point to the current query pointer.
+        // (2) Capture query start, then advance pointer by chunk size.
         let query_start = self.query_pointer.clone();
 
-        // (b) Push forward the query pointer by the amount specified in the chunk.
-        self.query_pointer = match self.query_pointer.clone().move_forward(chunk.size()) {
-            Some(pointer) => pointer,
-            None => {
-                return Some(Err(Error::IntervalStepthroughOutOfBounds(
-                    String::from("query forward by chunk size"),
-                    self.query_pointer.clone(),
-                    chunk.size(),
-                )));
-            }
-        };
+        if !self.query_pointer.move_forward(chunk.size()) {
+            return Some(Err(Error::IntervalStepthroughOutOfBounds(
+                String::from("query forward by chunk size"),
+                self.query_pointer.clone(),
+                chunk.size(),
+            )));
+        }
 
-        // (c) Set the query end to point to the current query pointer.
         let query_end = self.query_pointer.clone();
-
-        // (d) Create the query interval.
         let query = match Interval::try_new(query_start, query_end) {
             Ok(interval) => interval,
             Err(err) => return Some(Err(Error::Interval(err))),
         };
 
-        // (3) Adjust the pointers to the current query and reference locations.
-        // (a) If there is a query offset, add it to the query pointer.
+        // (3) Adjust pointers for gaps.
         if let Some(dq) = chunk.dq() {
-            self.query_pointer = match self.query_pointer.clone().move_forward(dq) {
-                Some(coordinate) => coordinate,
-                None => {
-                    return Some(Err(Error::IntervalStepthroughOutOfBounds(
-                        String::from("query forward by dq"),
-                        self.query_pointer.clone(),
-                        dq,
-                    )));
-                }
+            if !self.query_pointer.move_forward(dq) {
+                return Some(Err(Error::IntervalStepthroughOutOfBounds(
+                    String::from("query forward by dq"),
+                    self.query_pointer.clone(),
+                    dq,
+                )));
             }
         }
 
-        // (b) If there is a reference offset, add it to the reference pointer.
         if let Some(dt) = chunk.dt() {
-            self.reference_pointer = match self.reference_pointer.clone().move_forward(dt) {
-                Some(coordinate) => coordinate,
-                None => {
-                    return Some(Err(Error::IntervalStepthroughOutOfBounds(
-                        String::from("reference forward by dt"),
-                        self.reference_pointer.clone(),
-                        dt,
-                    )));
-                }
+            if !self.reference_pointer.move_forward(dt) {
+                return Some(Err(Error::IntervalStepthroughOutOfBounds(
+                    String::from("reference forward by dt"),
+                    self.reference_pointer.clone(),
+                    dt,
+                )));
             }
         }
 
@@ -253,6 +229,7 @@ impl Iterator for StepThrough {
 
 #[cfg(test)]
 mod tests {
+    use omics::coordinate::Contig;
     use omics::coordinate::Strand;
     use omics::coordinate::interbase::Coordinate;
     use omics::coordinate::interval::interbase::Interval;
@@ -278,13 +255,13 @@ mod tests {
         let result = stepthrough.next().unwrap().unwrap();
 
         let reference = Interval::try_new(
-            Coordinate::new("seq0", Strand::Positive, 0u64),
-            Coordinate::new("seq0", Strand::Positive, 3u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 0u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 3u64),
         )?;
 
         let query = Interval::try_new(
-            Coordinate::new("seq0", Strand::Negative, 5u64),
-            Coordinate::new("seq0", Strand::Negative, 2u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 5u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 2u64),
         )?;
 
         assert_eq!(result.reference(), &reference);
@@ -297,13 +274,13 @@ mod tests {
         let result = stepthrough.next().unwrap().unwrap();
 
         let reference = Interval::try_new(
-            Coordinate::new("seq0", Strand::Positive, 3u64),
-            Coordinate::new("seq0", Strand::Positive, 4u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 3u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 4u64),
         )?;
 
         let query = Interval::try_new(
-            Coordinate::new("seq0", Strand::Negative, 1u64),
-            Coordinate::new("seq0", Strand::Negative, 0u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 1u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 0u64),
         )?;
 
         assert_eq!(result.reference(), &reference);
@@ -338,13 +315,13 @@ mod tests {
         let result = stepthrough.next().unwrap().unwrap();
 
         let reference = Interval::try_new(
-            Coordinate::new("seq0", Strand::Positive, 0u64),
-            Coordinate::new("seq0", Strand::Positive, 2u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 0u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 2u64),
         )?;
 
         let query = Interval::try_new(
-            Coordinate::new("seq0", Strand::Negative, 9u64),
-            Coordinate::new("seq0", Strand::Negative, 7u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 9u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 7u64),
         )?;
 
         assert_eq!(result.reference(), &reference);
@@ -357,13 +334,13 @@ mod tests {
         let result = stepthrough.next().unwrap().unwrap();
 
         let reference = Interval::try_new(
-            Coordinate::new("seq0", Strand::Positive, 2u64),
-            Coordinate::new("seq0", Strand::Positive, 3u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 2u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 3u64),
         )?;
 
         let query = Interval::try_new(
-            Coordinate::new("seq0", Strand::Negative, 6u64),
-            Coordinate::new("seq0", Strand::Negative, 5u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 6u64),
+            Coordinate::new(Contig::new_unchecked("seq0"), Strand::Negative, 5u64),
         )?;
 
         assert_eq!(result.reference(), &reference);

--- a/src/liftover/stepthrough/interval_pair.rs
+++ b/src/liftover/stepthrough/interval_pair.rs
@@ -162,6 +162,7 @@ impl ContiguousIntervalPair {
     ///
     /// ```
     /// use chainfile::liftover::stepthrough::interval_pair::ContiguousIntervalPair;
+    /// use omics::coordinate::Contig;
     /// use omics::coordinate::Strand;
     /// use omics::coordinate::interbase::Coordinate;
     /// use omics::coordinate::interval::interbase::Interval;
@@ -172,8 +173,8 @@ impl ContiguousIntervalPair {
     /// let query = "seq1:+:1000-2000".parse::<Interval>()?;
     /// let pair = ContiguousIntervalPair::try_new(reference, query)?;
     ///
-    /// let old = Coordinate::new("seq0", Strand::Positive, 50u64);
-    /// let new = Coordinate::new("seq1", Strand::Positive, 1050u64);
+    /// let old = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 50u64);
+    /// let new = Coordinate::new(Contig::new_unchecked("seq1"), Strand::Positive, 1050u64);
     /// let lifted = pair.liftover(&old).unwrap();
     ///
     /// assert_eq!(new, lifted);
@@ -184,8 +185,8 @@ impl ContiguousIntervalPair {
     /// let query = "seq1:-:2000-1000".parse::<Interval>()?;
     /// let pair = ContiguousIntervalPair::try_new(reference, query)?;
     ///
-    /// let old = Coordinate::new("seq0", Strand::Positive, 50u64);
-    /// let new = Coordinate::new("seq1", Strand::Negative, 1950u64);
+    /// let old = Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 50u64);
+    /// let new = Coordinate::new(Contig::new_unchecked("seq1"), Strand::Negative, 1950u64);
     /// let lifted = pair.liftover(&old).unwrap();
     ///
     /// assert_eq!(new, lifted);
@@ -205,6 +206,7 @@ impl ContiguousIntervalPair {
     ///
     /// ```
     /// use chainfile::liftover::stepthrough::interval_pair::ContiguousIntervalPair;
+    /// use omics::coordinate::Contig;
     /// use omics::coordinate::Strand;
     /// use omics::coordinate::interbase::Coordinate;
     /// use omics::coordinate::interval::interbase::Interval;
@@ -220,19 +222,19 @@ impl ContiguousIntervalPair {
     ///
     /// assert_eq!(
     ///     result.reference().start(),
-    ///     &Coordinate::new("seq0", Strand::Positive, 50u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 50u64)
     /// );
     /// assert_eq!(
     ///     result.reference().end(),
-    ///     &Coordinate::new("seq0", Strand::Positive, 51u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 51u64)
     /// );
     /// assert_eq!(
     ///     result.query().start(),
-    ///     &Coordinate::new("seq1", Strand::Positive, 1050u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq1"), Strand::Positive, 1050u64)
     /// );
     /// assert_eq!(
     ///     result.query().end(),
-    ///     &Coordinate::new("seq1", Strand::Positive, 1051u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq1"), Strand::Positive, 1051u64)
     /// );
     ///
     /// // Positive-stranded to negative-stranded
@@ -246,19 +248,19 @@ impl ContiguousIntervalPair {
     ///
     /// assert_eq!(
     ///     result.reference().start(),
-    ///     &Coordinate::new("seq0", Strand::Positive, 50u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 50u64)
     /// );
     /// assert_eq!(
     ///     result.reference().end(),
-    ///     &Coordinate::new("seq0", Strand::Positive, 51u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq0"), Strand::Positive, 51u64)
     /// );
     /// assert_eq!(
     ///     result.query().start(),
-    ///     &Coordinate::new("seq1", Strand::Negative, 1950u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq1"), Strand::Negative, 1950u64)
     /// );
     /// assert_eq!(
     ///     result.query().end(),
-    ///     &Coordinate::new("seq1", Strand::Negative, 1949u64)
+    ///     &Coordinate::new(Contig::new_unchecked("seq1"), Strand::Negative, 1949u64)
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -289,12 +291,12 @@ impl ContiguousIntervalPair {
                 &reference
                     .end()
                     .clone()
-                    .move_backward(1)
+                    .into_move_backward(1)
                     .filter(|coord| self.reference().contains_coordinate(coord))
                     .unwrap(),
             )
             .unwrap()
-            .move_forward(1)
+            .into_move_forward(1)
             .unwrap();
 
         let query = Interval::try_new(query_start, query_end).unwrap();


### PR DESCRIPTION
Profiling revealed several hot paths where unnecessary cloning and allocation dominated liftover cost. This change addresses the highest impact sites, bumps `omics` to `v0.4.0` (which introduces `Arc<str>`-backed `Contig` for `O(1)` clones), adds Criterion benchmarks, and makes liftover results deterministic.

**Data layout.** `AnnotatedPair` now stores a `chain_id: usize` instead of a full `Header`, with a single `HashMap<usize, Header>` side table on `Machine`. This eliminates per-block header clones during machine building and per-hit header clones during liftover. The builder uses the `Entry` API to skip redundant header clones for duplicate chain sections.

**Liftover hot path.** Lapper results are filtered by strand before cloning `AnnotatedPair`. The per-call `HashMap` grouping is replaced with a sort-and-linear-scan over a flat `Vec`, producing chain-ID-ascending order in one pass.

**Stepthrough.** The consuming `move_forward`/`move_backward` coordinate methods are replaced with in-place `&mut self` variants, cutting per-step clones from 8–12 down to 4. `Contig` creation is hoisted out of the inner stepthrough loop. Eager `split().collect::<Vec<_>>()` is replaced with `splitn(4, ...)` in alignment data parsing.

**Deterministic ordering.** `Machine::liftover()` now returns results sorted by chain ID ascending, then score descending. Segments within each result are sorted by reference start position. The `compare-crossmap` binary's best-chain selection now breaks ties deterministically.

**Benchmarks.** Criterion benchmarks cover single-position liftover, interval liftover, machine building, query-only throughput, and end-to-end throughput. Query intervals are pre-generated outside timed loops using a fixed-seed `StdRng` for reproducibility.

**`omics` upgrade.** Bumps `omics` from `v0.2.0` to `v0.4.0`, adopting `Arc<str>`-backed `Contig` for `O(1)` clones, the new `Contig` validation API, and in-place coordinate move methods.

### Performance

Measured with Criterion on an Apple M3 Max, comparing `main` (post-PR #9) against this branch. The synthetic workload uses a 25-chromosome chain file with ~600 chains per chromosome.

Across the board, throughput roughly doubles—with the largest gains in interval-heavy liftover where the old code was cloning full `Header` structs on every lapper hit:

- **Liftover (1K single-position queries):** 506µs → 222µs (56% faster)
- **Liftover (interval straddling gaps):** 306µs → 70µs (77% faster)
- **Machine building (large, ~15K chains):** 92.6ms → 32.0ms (65% faster)
- **Query-only throughput (100K queries):** 52.8ms → 22.7ms (57% faster)
- **End-to-end, build + 100K queries:** 63.5ms → 26.0ms (59% faster)

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] You have added any relevant tags to the pull request.
- [x] Your code builds clean without any errors or warnings (use `cargo test` and `cargo clippy`).
- [x] You have added tests (when appropriate).
- [x] You have updated the wiki (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added an entry in the `CHANGELOG.md`.